### PR TITLE
Modified neuralnet.py to work with tensorflow 2.0.0

### DIFF
--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -3,12 +3,19 @@ import logging
 import math
 import time
 import base64
+from distutils.version import LooseVersion
 
 import mloop.utilities as mlu
 import numpy as np
 import numpy.random as nr
 import sklearn.preprocessing as skp
-import tensorflow as tf
+# Import tensorflow with backwards compatability if version is 2.0.0 or newer.
+from tensorflow import __version__ as tf_version
+if LooseVersion(tf_version) < LooseVersion('2.0.0'):
+    import tensorflow as tf
+else:
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
 
 class SingleNeuralNet():
     '''


### PR DESCRIPTION
Workaround for TensorFlow 2.0.0 broken backwards compatibility, Fixes # 37.

Changes proposed in this pull request:

- Have Tensorflow fall back to v1 behavior when using version >= 2.0.0
- Added import from standard library (distutils.version.LooseVersion) for version check

@qctrl/support
