### PR TITLE
Remove plotly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ docutils>=0.3
 numpy>=1.11
 scipy>=0.17
 matplotlib>=1.5
-plotly>=2.0.8
 pytest>=2.9
 scikit-learn>=0.18
 setuptools>=26

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ def main():
                             'numpy>=1.11',
                             'scipy>=0.17',
                             'matplotlib>=1.5',
-                            'plotly>=2.0.8',
                             'pytest>=2.9',
                             'scikit-learn>=0.18',
                             'tensorflow>=1.2.0'],


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove ability to automatically upload plots with plotly from `NeuralNetVisualizer`
- Remove plotly as a dependency

Note that this does break backwards compatibility since a call to e.g. `create_neural_net_learner_visualizations()` with the `upload_cross_sections` keyword argument provided will now error. It's a pretty minor change though that's easy for users to fix.

@qctrl/support @charmasaur 
