### PR TITLE
Generalize ControllerVisualizer to plot data from incomplete optimizations.

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -241,9 +241,6 @@ class ControllerVisualizer():
         in_costs = self.in_costs[:self.num_in_costs]
         in_uncers = self.in_uncers[:self.num_in_costs]
         
-        # if self.num_in_costs != self.num_out_params:
-        #     self.log.warning('Unable to plot parameters vs costs, unequal number. in_costs:' + repr(self.num_in_costs) + ' out_params:' + repr(self.num_out_params))
-        #     return
         global figure_counter, run_label, run_label, scale_param_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)


### PR DESCRIPTION
Changes proposed in this pull request:

- Generalize `ControllerVisualizer` methods to plot data from archives of incomplete runs.
  - Incomplete runs may be those still in progress, those ended due to errors, those ended to a keyboard interupt, etc..
- Un-commented out `visualization.plot_parameters_vs_cost()` in `create_controller_visualizations()` in `visualizations.py`.
  - That plotting method works fine as far as I can tell so I'm not sure why it was commented out in the first place. Maybe just for debugging purposes then it was accidentally committed?

@qctrl/support
@michaelhush @charmasaur 