### PR TITLE
Support Plotting Subsets of Parameters

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -746,7 +746,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
             artists = []
             for ind in range(self.num_params):
                 artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind], linestyle='-'))
-            plt.legend(artists,[str(x) for x in range(1,self.num_params+1)],loc=legend_loc)
+            plt.legend(artists,[str(x) for x in range(self.num_params)],loc=legend_loc)
         if self.num_nets > 1:
             # And now create a plot showing the average, max and min for each cross section.
             def prepare_plot():
@@ -784,7 +784,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
             prepare_plot()
             for ind in range(self.num_params):
                 artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind], linestyle='-'))
-            plt.legend(artists,[str(x) for x in range(1,self.num_params+1)],loc=legend_loc)
+            plt.legend(artists,[str(x) for x in range(self.num_params)],loc=legend_loc)
 
     def plot_surface(self):
         '''

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -88,6 +88,26 @@ def _color_list_from_num_of_params(num_of_params):
     global cmap
     return [cmap(float(x)/num_of_params) for x in range(num_of_params)]
 
+def _ensure_parameter_subset_valid(visualizer, parameter_subset):
+    '''
+    Make sure indices in parameter_subset are acceptable.
+    
+    Args:
+        visualizer (ControllerVisualizer-like): An instance of one of the
+            visualization classes defined in this module, which should have the
+            attributes param_numbers and log.
+        parameter_subset (list-like): The indices corresponding to a subset of
+            the optimization parameters. The indices should be 0-based, i.e. the
+            first parameter is identified with index 0. Generally the values of
+            the indices in parameter_subset should be integers between 0 and the
+            number of parameters minus one, inclusively.
+    '''
+    for ind in parameter_subset:
+        if ind not in visualizer.param_numbers:
+            message = '{ind} is not a valid parameter index.'.format(ind=ind)
+            visualizer.log.error(message)
+            raise ValueError(message)
+
 def configure_plots():
     '''
     Configure the setting for the plots.
@@ -207,13 +227,7 @@ class ControllerVisualizer():
         plt.legend(artists,self.unique_types,loc=legend_loc)
     
     def _ensure_parameter_subset_valid(self, parameter_subset):
-        # Ensure all indices are valid.
-        for ind in parameter_subset:
-            if ind not in self.param_numbers:
-                message = '{ind} is not a valid parameter index.'.format(ind=ind)
-                self.log.error(message)
-                raise ValueError(message)
-        
+        _ensure_parameter_subset_valid(self, parameter_subset)
         
     def plot_parameters_vs_run(self, parameter_subset=None):
         '''

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -178,7 +178,7 @@ class ControllerVisualizer():
         self.cost_colors = [_color_from_controller_name(x) for x in self.out_type]
         self.in_numbers = np.arange(1,self.num_in_costs+1)
         self.out_numbers = np.arange(1,self.num_out_params+1)
-        self.param_numbers = np.arange(1,self.num_params+1)
+        self.param_numbers = np.arange(self.num_params)
         self.param_colors = _color_list_from_num_of_params(self.num_params)
         
     def plot_cost_vs_run(self):
@@ -214,10 +214,10 @@ class ControllerVisualizer():
     
         Args:
             parameter_subset (list-like): The indices of parameters to plot. The
-                indices should be 1-based, i.e. the first parameter is
-                identified with index 1, not index 0. Generally the values of
-                the indices in parameter_subset should be between 1 and the
-                number of parameters, inclusively. If set to `None`, then all
+                indices should be 0-based, i.e. the first parameter is
+                identified with index 0. Generally the values of the indices in
+                parameter_subset should be between 0 and the number of
+                parameters minus one, inclusively. If set to `None`, then all
                 parameters will be plotted. Default None.
         '''
         # Get default value for parameter_subset if necessary.
@@ -227,27 +227,23 @@ class ControllerVisualizer():
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
             
-        # Account for 1-indexing. This is a little inelegant but it makes the
-        # provided indices correspond to the indices in the legend.
-        parameter_subset_0 = np.array(parameter_subset) - 1
-            
         global figure_counter, run_label, scale_param_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
         if self.finite_flag:
-            for ind in parameter_subset_0:
+            for ind in parameter_subset:
                 plt.plot(self.out_numbers,self.scaled_params[:,ind],'o',color=self.param_colors[ind])
                 plt.ylabel(scale_param_label)
                 plt.ylim((0,1))
         else:
-            for ind in parameter_subset_0:
+            for ind in parameter_subset:
                 plt.plot(self.out_numbers,self.out_params[:,ind],'o',color=self.param_colors[ind])
                 plt.ylabel(run_label)
         plt.xlabel(run_label)
         
         plt.title('Controller: Parameters vs run number.')
         artists=[]
-        for ind in parameter_subset_0:
+        for ind in parameter_subset:
             artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind],marker='o',linestyle=''))
         plt.legend(artists,[str(x) for x in parameter_subset],loc=legend_loc)
         
@@ -279,7 +275,7 @@ class ControllerVisualizer():
         artists=[]
         for ind in range(self.num_params):
             artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind],marker='o',linestyle=''))
-        plt.legend(artists,[str(x) for x in range(1,self.num_params+1)], loc=legend_loc)
+        plt.legend(artists,[str(x) for x in range(self.num_params)], loc=legend_loc)
 
 def create_differential_evolution_learner_visualizations(filename,
                                                          file_type='pkl',

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -380,7 +380,7 @@ class DifferentialEvolutionVisualizer():
         artists=[]
         for ind in range(self.num_params):
             artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind],marker='o',linestyle=''))
-        plt.legend(artists,[str(x) for x in range(1,self.num_params+1)],loc=legend_loc)
+        plt.legend(artists,[str(x) for x in range(self.num_params)],loc=legend_loc)
         
 def create_gaussian_process_learner_visualizations(filename,
                                                    file_type='pkl',

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -200,12 +200,6 @@ class ControllerVisualizer():
         plt.legend(artists,self.unique_types,loc=legend_loc)
     
     def _ensure_parameter_subset_valid(self, parameter_subset):
-        # Make sure that parameter_subset is iterable.
-        if not hasattr(parameter_subset, '__iter__'):
-            message = 'parameter_subset should be a list, or list-like.'
-            self.log.error(message)
-            raise ValueError(message)
-            
         # Ensure all indices are valid.
         for ind in parameter_subset:
             if ind not in self.param_numbers:

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -263,9 +263,17 @@ class ControllerVisualizer():
             artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
         plt.legend(artists,[str(x) for x in parameter_subset],loc=legend_loc)
         
-    def plot_parameters_vs_cost(self):
+    def plot_parameters_vs_cost(self, parameter_subset=None):
         '''
         Create a plot of the parameters versus run number.
+    
+        Args:
+            parameter_subset (list-like): The indices of parameters to plot. The
+                indices should be 0-based, i.e. the first parameter is
+                identified with index 0. Generally the values of the indices in
+                parameter_subset should be between 0 and the number of
+                parameters minus one, inclusively. If set to `None`, then all
+                parameters will be plotted. Default None.
         '''
         # Only plot points for which a cost was actually measured. This may not
         # be the case for all parameter sets if the optimization is still in
@@ -273,30 +281,46 @@ class ControllerVisualizer():
         in_costs = self.in_costs[:self.num_in_costs]
         in_uncers = self.in_uncers[:self.num_in_costs]
         
+        # Get default value for parameter_subset if necessary.
+        if parameter_subset is None:
+            parameter_subset = self.param_numbers
+        
+        # Make sure that the provided parameter_subset is acceptable.
+        self._ensure_parameter_subset_valid(parameter_subset)
+        
+        # Generate set of distinct colors for plotting.
+        num_params = len(parameter_subset)
+        param_colors = _color_list_from_num_of_params(num_params)
+        
         global figure_counter, run_label, run_label, scale_param_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
         
         if self.finite_flag:
             scaled_params = self.scaled_params[:self.num_in_costs,:]
-            for ind in range(self.num_params):
-                plt.plot(scaled_params[:,ind], in_costs + in_uncers,'_',color=self.param_colors[ind])
-                plt.plot(scaled_params[:,ind], in_costs - in_uncers,'_',color=self.param_colors[ind])
-                plt.plot(scaled_params[:,ind], in_costs,'o',color=self.param_colors[ind])
+            for ind in range(num_params):
+                param_index = parameter_subset[ind]
+                color = param_colors[ind]
+                plt.plot(scaled_params[:,param_index], in_costs + in_uncers,'_',color=color)
+                plt.plot(scaled_params[:,param_index], in_costs - in_uncers,'_',color=color)
+                plt.plot(scaled_params[:,param_index], in_costs,'o',color=color)
                 plt.xlabel(scale_param_label)
                 plt.xlim((0,1))
         else:
             out_params = self.out_params[:self.num_in_costs, :]
-            for ind in range(self.num_params):
-                plt.plot(out_params[:,ind], in_costs + in_uncers,'_',color=self.param_colors[ind])
-                plt.plot(out_params[:,ind], in_costs - in_uncers,'_',color=self.param_colors[ind])
-                plt.plot(out_params[:,ind], in_costs,'o',color=self.param_colors[ind])
+            for ind in range(num_params):
+                param_index = parameter_subset[ind]
+                color = param_colors[ind]
+                plt.plot(out_params[:,param_index], in_costs + in_uncers,'_',color=color)
+                plt.plot(out_params[:,param_index], in_costs - in_uncers,'_',color=color)
+                plt.plot(out_params[:,param_index], in_costs,'o',color=color)
                 plt.xlabel(run_label)
         plt.ylabel(cost_label)
         plt.title('Controller: Cost vs parameters.')
         artists=[]
-        for ind in range(self.num_params):
-            artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind],marker='o',linestyle=''))
+        for ind in range(num_params):
+            color = param_colors[ind]
+            artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
         plt.legend(artists,[str(x) for x in range(self.num_params)], loc=legend_loc)
 
 def create_differential_evolution_learner_visualizations(filename,

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -335,7 +335,7 @@ class ControllerVisualizer():
         for ind in range(num_params):
             color = param_colors[ind]
             artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
-        plt.legend(artists,[str(x) for x in range(self.num_params)], loc=legend_loc)
+        plt.legend(artists,[str(x) for x in parameter_subset], loc=legend_loc)
 
 def create_differential_evolution_learner_visualizations(filename,
                                                          file_type='pkl',

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -179,7 +179,6 @@ class ControllerVisualizer():
         self.in_numbers = np.arange(1,self.num_in_costs+1)
         self.out_numbers = np.arange(1,self.num_out_params+1)
         self.param_numbers = np.arange(self.num_params)
-        self.param_colors = _color_list_from_num_of_params(self.num_params)
         
     def plot_cost_vs_run(self):
         '''
@@ -226,25 +225,34 @@ class ControllerVisualizer():
         
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
+        
+        # Generate set of distinct colors for plotting.
+        num_params = len(parameter_subset)
+        param_colors = _color_list_from_num_of_params(num_params)
             
         global figure_counter, run_label, scale_param_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
         if self.finite_flag:
-            for ind in parameter_subset:
-                plt.plot(self.out_numbers,self.scaled_params[:,ind],'o',color=self.param_colors[ind])
+            for ind in range(num_params):
+                param_index = parameter_subset[ind]
+                color = param_colors[ind]
+                plt.plot(self.out_numbers,self.scaled_params[:,param_index],'o',color=color)
                 plt.ylabel(scale_param_label)
                 plt.ylim((0,1))
         else:
-            for ind in parameter_subset:
-                plt.plot(self.out_numbers,self.out_params[:,ind],'o',color=self.param_colors[ind])
+            for ind in range(num_params):
+                param_index = parameter_subset[ind]
+                color = param_colors[ind]
+                plt.plot(self.out_numbers,self.out_params[:,param_index],'o',color=color)
                 plt.ylabel(run_label)
         plt.xlabel(run_label)
         
         plt.title('Controller: Parameters vs run number.')
         artists=[]
-        for ind in parameter_subset:
-            artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind],marker='o',linestyle=''))
+        for ind in range(num_params):
+            color = param_colors[ind]
+            artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
         plt.legend(artists,[str(x) for x in parameter_subset],loc=legend_loc)
         
     def plot_parameters_vs_cost(self):

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -521,7 +521,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         artists = []
         for ind in range(self.num_params):
             artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind], linestyle='-'))
-        plt.legend(artists,[str(x) for x in range(1,self.num_params+1)],loc=legend_loc)    
+        plt.legend(artists,[str(x) for x in range(self.num_params)],loc=legend_loc)    
     
     '''
     Method is currently not supported. Of questionable usefulness. Not yet deleted.
@@ -557,7 +557,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         artists = []
         for ind in range(self.num_params):
             artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind],marker='o',linestyle=''))
-        plt.legend(artists, [str(x) for x in range(1,self.num_params+1)], loc=legend_loc)
+        plt.legend(artists, [str(x) for x in range(self.num_params)], loc=legend_loc)
     '''
     
     def plot_hyperparameters_vs_run(self):
@@ -580,7 +580,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             artists=[]
             for ind in range(self.num_params):
                 artists.append(plt.Line2D((0,1),(0,0), color=self.param_colors[ind],marker='o',linestyle=''))
-            plt.legend(artists,[str(x) for x in range(1,self.num_params+1)],loc=legend_loc)
+            plt.legend(artists,[str(x) for x in range(self.num_params)],loc=legend_loc)
             
         if self.cost_has_noise:
             figure_counter += 1


### PR DESCRIPTION
Changes proposed in this pull request:

- Add optional `parameter_subset` option to some visualization methods so that results for only some optimization parameters are displayed.
  - Default behavior is to display data for all parameters, so this change is backwards compatible.
  - Plots with results for many parameters can be messy and hard to interpret, and this change can help alleviate that.
  - Parameters are now 0-indexed (instead of 1-indexed) in legends so that the indices in them line up with the indices passed in `parameter_subset`.


@qctrl/support
