### PR TITLE
Improved path handling

### DIFF
--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -177,10 +177,23 @@ class Controller():
         if controller_archive_filename is None:
             self.controller_archive_filename = None
         else:
-            if not os.path.exists(mlu.archive_foldername):
-                os.makedirs(mlu.archive_foldername)
-            self.controller_archive_filename =str(controller_archive_filename)
-            self.total_archive_filename = mlu.archive_foldername + self.controller_archive_filename + '_' + mlu.datetime_to_string(self.start_datetime) + '.' + self.controller_archive_file_type
+            # Store self.controller_archive_filename without any path, but
+            # include any path components in controller_archive_filename when
+            # constructing the full path.
+            controller_archive_filename = str(controller_archive_filename)
+            self.controller_archive_filename = os.path.basename(controller_archive_filename)
+            filename_suffix = mlu.generate_filename_suffix(
+                self.controller_archive_file_type,
+                file_datetime=self.start_datetime,
+            )
+            filename = controller_archive_filename + filename_suffix
+            self.total_archive_filename = os.path.join(mlu.archive_foldername, filename)
+            
+            # Include any path info from controller_archive_filename when
+            # creating directory for archive files.]
+            archive_dir = os.path.dirname(self.total_archive_filename)
+            if not os.path.exists(archive_dir):
+                os.makedirs(archive_dir)
 
         self.archive_dict = {'archive_type':'controller',
                              'num_out_params':self.num_out_params,

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1618,12 +1618,13 @@ class NeuralNetLearner(Learner, mp.Process):
         self.log = None
 
     def _construct_net(self):
-        neural_net_args = {
-            'num_params': self.num_params,
-            'learner_archive_dir': self.learner_archive_dir,
-            'start_datetime': self.start_datetime,
-        }
-        self.neural_net = [mlnn.NeuralNet(**neural_net_args) for _ in range(self.num_nets)]
+        self.neural_net = [
+            mlnn.NeuralNet(
+                num_params=self.num_params,
+                learner_archive_dir=self.learner_archive_dir,
+                start_datetime=self.start_datetime)
+            for _ in range(self.num_nets)
+        ]
 
     def _init_cost_scaler(self):
         '''

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -135,9 +135,10 @@ class Learner():
             
             # Include any path info from learner_archive_filename when creating
             # directory for archive files.
-            archive_dir = os.path.dirname(self.total_archive_filename)
-            if not os.path.exists(archive_dir):
-                os.makedirs(archive_dir)
+            learner_archive_dir = os.path.dirname(self.total_archive_filename)
+            self.learner_archive_dir = learner_archive_dir
+            if not os.path.exists(learner_archive_dir):
+                os.makedirs(learner_archive_dir)
         
         self.archive_dict = {'archive_type':'learner',
                              'num_params':self.num_params,
@@ -1614,7 +1615,12 @@ class NeuralNetLearner(Learner, mp.Process):
         self.log = None
 
     def _construct_net(self):
-        self.neural_net = [mlnn.NeuralNet(self.num_params) for _ in range(self.num_nets)]
+        neural_net_args = {
+            'num_params': self.num_params,
+            'learner_archive_dir': self.learner_archive_dir,
+            'start_datetime': self.start_datetime,
+        }
+        self.neural_net = [mlnn.NeuralNet(**neural_net_args) for _ in range(self.num_nets)]
 
     def _init_cost_scaler(self):
         '''

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1569,7 +1569,6 @@ class NeuralNetLearner(Learner, mp.Process):
         self.bad_uncer_frac = 0.1 #Fraction of cost range to set a bad run uncertainty
 
         #Optional user set variables
-        self.nn_training_filename = nn_training_filename
         self.predict_global_minima_at_end = bool(predict_global_minima_at_end)
         self.minimum_uncertainty = float(minimum_uncertainty)
         if default_bad_cost is not None:

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1477,6 +1477,7 @@ class NeuralNetLearner(Learner, mp.Process):
             nn_training_file_type = str(nn_training_file_type)
             if not mlu.check_file_type_supported(nn_training_file_type):
                 self.log.error('NN training file type not supported' + repr(nn_training_file_type))
+            self.nn_training_file_dir = os.path.dirname(nn_training_filename)
             
             self.training_dict = mlu.get_dict_from_file(nn_training_filename, nn_training_file_type)
             
@@ -1526,6 +1527,7 @@ class NeuralNetLearner(Learner, mp.Process):
                              max_boundary=max_boundary, 
                              **kwargs)
         else:
+            self.nn_training_file_dir = None
             
             super(NeuralNetLearner,self).__init__(**kwargs)
         
@@ -1567,6 +1569,7 @@ class NeuralNetLearner(Learner, mp.Process):
         self.bad_uncer_frac = 0.1 #Fraction of cost range to set a bad run uncertainty
 
         #Optional user set variables
+        self.nn_training_filename = nn_training_filename
         self.predict_global_minima_at_end = bool(predict_global_minima_at_end)
         self.minimum_uncertainty = float(minimum_uncertainty)
         if default_bad_cost is not None:
@@ -1645,7 +1648,8 @@ class NeuralNetLearner(Learner, mp.Process):
             raise ValueError
         self._construct_net()
         for i, n in enumerate(self.neural_net):
-            n.load(self.training_dict['net_' + str(i)])
+            n.load(self.training_dict['net_' + str(i)],
+                   extra_search_dirs=[self.nn_training_file_dir])
 
     def _fit_neural_net(self,index):
         '''

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -121,10 +121,23 @@ class Learner():
         if learner_archive_filename is None:
             self.learner_archive_filename = None
         else:
-            if not os.path.exists(mlu.archive_foldername):
-                os.makedirs(mlu.archive_foldername)
-            self.learner_archive_filename =str(learner_archive_filename)
-            self.total_archive_filename = mlu.archive_foldername + self.learner_archive_filename + '_' + mlu.datetime_to_string(self.start_datetime) + '.' + self.learner_archive_file_type
+            # Store self.learner_archive_filename without any path, but include
+            # any path components in learner_archive_filename when constructing
+            # the full path.
+            learner_archive_filename = str(learner_archive_filename)
+            self.learner_archive_filename = os.path.basename(learner_archive_filename)
+            filename_suffix = mlu.generate_filename_suffix(
+                self.learner_archive_file_type,
+                file_datetime=self.start_datetime,
+            )
+            filename = learner_archive_filename + filename_suffix
+            self.total_archive_filename = os.path.join(mlu.archive_foldername, filename)
+            
+            # Include any path info from learner_archive_filename when creating
+            # directory for archive files.
+            archive_dir = os.path.dirname(self.total_archive_filename)
+            if not os.path.exists(archive_dir):
+                os.makedirs(archive_dir)
         
         self.archive_dict = {'archive_type':'learner',
                              'num_params':self.num_params,

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import math
+import os
 import time
 import base64
 from distutils.version import LooseVersion
@@ -52,15 +53,9 @@ class SingleNeuralNet():
         self.log = logging.getLogger(__name__)
         start = time.time()
 
-        self.save_archive_filename = (
-                mlu.archive_foldername
-                + "neural_net_archive_"
-                + mlu.datetime_to_string(datetime.datetime.now())
-                + "_"
-                # We include 6 random bytes for deduplication in case multiple nets
-                # are created at the same time.
-                + base64.urlsafe_b64encode(nr.bytes(6)).decode()
-                + ".ckpt")
+        filename_suffix = mlu.generate_filename_suffix('ckpt', random_bytes=True)
+        filename = 'neural_net_archive' + filename_suffix
+        self.save_archive_filename = os.path.join(mlu.archive_foldername, filename)
 
         self.log.info("Constructing net")
         self.graph = tf.Graph()

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -32,7 +32,7 @@ default_interface_file_type = 'txt'
 
 archive_foldername = './M-LOOP_archives/'
 log_foldername = './M-LOOP_logs/'
-default_log_filename = 'M-LOOP_'
+default_log_filename = 'M-LOOP'
 
 filewrite_wait = 0.1
 
@@ -67,8 +67,8 @@ def _config_logger(log_filename = default_log_filename,
     if len(log.handlers) == 0:
         log.setLevel(min(file_log_level,console_log_level))
         if log_filename is not None:
-            date_string = datetime_to_string(datetime.datetime.now())
-            full_filename = log_filename + date_string + '.log'
+            filename_suffix = generate_filename_suffix('log')
+            full_filename = log_filename + filename_suffix
             filename_with_path = os.path.join(log_foldername, full_filename)
             # Create folder if it doesn't exist, accounting for any parts of the
             # path that may have been included in log_filename.

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -11,6 +11,8 @@ import datetime
 import sys
 import os
 import numpy as np
+import numpy.random as nr
+import base64
 import mloop
 
 python_version = sys.version_info[0]
@@ -85,6 +87,41 @@ def datetime_to_string(datetime):
     Method for changing a datetime into a standard string format used by all packages.
     '''
     return datetime.strftime('%Y-%m-%d_%H-%M')
+
+def generate_filename_suffix(file_type, file_datetime=None, random_bytes=False):
+    '''
+    Method for generating a string with date and extension for end of file names.
+    
+    This method returns a string such as '_2020-06-13_04-20.txt' where the date
+    and time specify when this function was called.
+    
+    Args:
+        file_type (string): The extension to use at the end of the filename,
+            e.g. 'txt'. Note that the period should NOT be included.
+        file_datetime (Optional datetime.datetime): The date and time to use in
+            the filename suffix, represented as an instance of the datetime
+            class defined in the datetime module. If set to None, then this
+            function will use the result returned by datetime.datetime.now().
+            Default None.
+        random_bytes (Optional bool): If set to True, six random bytes will be
+            added to the filename suffix. This can be useful avoid duplication
+            if multiple filenames are created with the same datetime.
+        
+    Returns:
+        string: A string giving the suffix that can be appended to a filename
+            prefix to give a full filename with timestamp and extension, such as
+            '_2020-06-13_04-20.txt'. The date and time specify when this
+            function was called.
+    '''
+    if file_datetime is None:
+        file_datetime = datetime.datetime.now()
+    date_string = datetime_to_string(file_datetime)
+    filename_suffix = '_' + date_string 
+    if random_bytes:
+        random_string = base64.urlsafe_b64encode(nr.bytes(6)).decode()
+        filename_suffix = filename_suffix + '_' + random_string
+    filename_suffix = filename_suffix + '.' + file_type
+    return filename_suffix
 
 def dict_to_txt_file(tdict,filename):
     '''

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -61,16 +61,21 @@ def _config_logger(log_filename = default_log_filename,
     
     Returns:
         dictionary: Dict with extra keywords not used by the logging configuration.
-    '''
-    if not os.path.exists(log_foldername):
-        os.makedirs(log_foldername)
-    
+    '''    
     log = logging.getLogger('mloop')
     
     if len(log.handlers) == 0:
         log.setLevel(min(file_log_level,console_log_level))
         if log_filename is not None:
-            fh = logging.FileHandler(log_foldername + log_filename + datetime_to_string(datetime.datetime.now()) + '.log')
+            date_string = datetime_to_string(datetime.datetime.now())
+            full_filename = log_filename + date_string + '.log'
+            filename_with_path = os.path.join(log_foldername, full_filename)
+            # Create folder if it doesn't exist, accounting for any parts of the
+            # path that may have been included in log_filename.
+            actual_log_foldername = os.path.dirname(filename_with_path)
+            if not os.path.exists(actual_log_foldername):
+                os.makedirs(actual_log_foldername)
+            fh = logging.FileHandler(filename_with_path)
             fh.setLevel(file_log_level)
             fh.setFormatter(logging.Formatter('%(asctime)s %(name)-20s %(levelname)-8s %(message)s'))
             log.addHandler(fh)


### PR DESCRIPTION
Changes proposed in this pull request:

- Refactored some reused code into a `generate_filename_suffix()` function.
- Replace string manipulations with `os.path` functions where appropriate.
  - This also makes it possible to include absolute or relative paths when providing `log_filename`, `controller_archive_filename`, and/or `learner_archive_filename`.
  - The neural net archives are put into the same folder as their corresponding learner archive, even if it wasn't set to the default directory.
- Neural net visualization code now checks if neural net archives are in the same folder as the provided learner archive if they aren't found at the path specified in the learner archive.
  - This change makes it a bit more resilient to moving files around, e.g. when moving results from optimization runs into a long term storage location.
  - They are assumed to still have the same file name as specified in the learner archive.

Existing docstrings have been updated where changes were made, and docstrings were provided for new functions. All changes are backwards compatible and retain the old default behavior.

@qctrl/support, @michaelhush @charmasaur 
