### PR TITLE
Corrected indexing bug when fitting hyperparameters in NeuralNet.

### DIFF
--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -645,11 +645,12 @@ class NeuralNet():
                 # Fit regularisation
 
                 # Split the data into training and cross validation
-                cv_size = int(len(all_params) / 10)
-                train_params = all_params[:-cv_size]
-                train_costs = all_costs[:-cv_size]
-                cv_params = all_params[-cv_size:]
-                cv_costs = all_costs[-cv_size:]
+                training_fraction = 0.9
+                split_index = int(training_fraction * len(all_params))
+                train_params = all_params[:split_index]
+                train_costs = all_costs[:split_index]
+                cv_params = all_params[split_index:]
+                cv_costs = all_costs[split_index:]
 
                 orig_cv_loss = self.net.cross_validation_loss(cv_params, cv_costs)
                 best_cv_loss = orig_cv_loss

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -648,8 +648,8 @@ class NeuralNet():
                 cv_size = int(len(all_params) / 10)
                 train_params = all_params[:-cv_size]
                 train_costs = all_costs[:-cv_size]
-                cv_params = all_params[cv_size:]
-                cv_costs = all_costs[cv_size:]
+                cv_params = all_params[-cv_size:]
+                cv_costs = all_costs[-cv_size:]
 
                 orig_cv_loss = self.net.cross_validation_loss(cv_params, cv_costs)
                 best_cv_loss = orig_cv_loss

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -638,9 +638,11 @@ class NeuralNet():
         all_params, all_costs = self._scale_params_and_cost_list(all_params, all_costs)
 
         if self.fit_hyperparameters:
-            # Every 20 fits (starting at 5, just because), re-fit the hyperparameters
-            if int(len(all_params + 5) / 20) > self.last_hyperfit:
-                self.last_hyperfit = int(len(all_params + 5) / 20)
+            # Every 20 runs, re-fit the hyperparameters.
+            n_fits = len(all_params)
+            n_hyperfit = int(n_fits / 20.0)  # int() rounds down.
+            if n_hyperfit > self.last_hyperfit:
+                self.last_hyperfit = n_hyperfit
 
                 # Fit regularisation
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix indexing when dividing up data into a training set and cross validation set. This is done while fitting hyperparameters in `NeuralNet.fit_neural_net()`.
  - Previously 10% of the data would only be used for training, 10% would only be used for cross validation, and 80% would be used for both.

Things are set up in such a way that `self.fit_hyperparameters` is `False` for all instances of `NeuralNet` so the section of the code with this bug is never reached in normal operation. I was considering playing around with `self.fit_hyperparameters` though so I figured I'd submit this fix.

@qctrl/support @charmasaur 
