### PR TITLE
Visualization Refactoring and Enhancements.

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -920,13 +920,16 @@ class GaussianProcessLearner(Learner, mp.Process):
                  default_bad_uncertainty = None,
                  minimum_uncertainty = 1e-8,
                  gp_training_filename =None,
-                 gp_training_file_type ='txt',
+                 gp_training_file_type = None,
                  predict_global_minima_at_end = True,
                  **kwargs):
         
         if gp_training_filename is not None:
             
             gp_training_filename = str(gp_training_filename)
+            # Automatically determine gp_training_file_type if necessary.
+            if gp_training_file_type is None:
+                gp_training_file_type = mlu.get_file_type(gp_training_filename)
             gp_training_file_type = str(gp_training_file_type)
             if not mlu.check_file_type_supported(gp_training_file_type):
                 self.log.error('GP training file type not supported' + repr(gp_training_file_type))
@@ -1466,7 +1469,7 @@ class NeuralNetLearner(Learner, mp.Process):
                  default_bad_cost = None,
                  default_bad_uncertainty = None,
                  nn_training_filename =None,
-                 nn_training_file_type ='txt',
+                 nn_training_file_type =None,
                  minimum_uncertainty = 1e-8,
                  predict_global_minima_at_end = True,
                  **kwargs):
@@ -1474,6 +1477,9 @@ class NeuralNetLearner(Learner, mp.Process):
         if nn_training_filename is not None:
             
             nn_training_filename = str(nn_training_filename)
+            # Automatically determine file_type if necessary.
+            if nn_training_file_type is None:
+                nn_training_file_type = mlu.get_file_type(nn_training_filename)
             nn_training_file_type = str(nn_training_file_type)
             if not mlu.check_file_type_supported(nn_training_file_type):
                 self.log.error('NN training file type not supported' + repr(nn_training_file_type))

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -224,6 +224,61 @@ def get_file_type(filename):
     file_type = file_type[1:]  # Remove leading '.'.
     return file_type
 
+def get_controller_type_from_learner_archive(learner_filename):
+    '''
+    Determine the controller_type used in an optimization.
+    
+    This function returns the value used for controller_type during an
+    optimization run, determined by examining the optimization's learner
+    archive.
+    
+    Args:
+        learner_filename (String): The file name including extension, and
+            optionally including path, of a learner archive.
+
+    Returns:
+        controller_type (String): A string specifying the value for
+            controller_type used during the optimization run that produced the
+            provided learner archive.
+    '''
+    # Automatically determine file_type.
+    file_type = get_file_type(learner_filename)
+    
+    # Ensure file_type is supported.
+    log = logging.getLogger(__name__)
+    if not check_file_type_supported(file_type):
+        message = 'File type not supported: ' + repr(file_type)
+        log.error(message)
+        raise ValueError(message)
+    
+    # Get archive_type from the archive.
+    learner_dict = get_dict_from_file(learner_filename, file_type)
+    archive_type = learner_dict['archive_type']
+    
+    # Raise a helpful error if a controller archive was provided instead of a
+    # learner archive.
+    if archive_type == 'controller':
+        message = ('{filename} is a controller archive, not a '
+                   'learner archive.').format(filename=learner_filename)
+        log.error(message)
+        raise ValueError(message)
+    
+    # Convert archive_type to corresponding controller_type.
+    ARCHIVE_CONTROLLER_MAPPING = {
+        'gaussian_process_learner': 'gaussian_process',
+        'neural_net_learner': 'neural_net',
+        'differential_evolution': 'differential_evolution',
+    }
+    if archive_type in ARCHIVE_CONTROLLER_MAPPING:
+        controller_type = ARCHIVE_CONTROLLER_MAPPING[archive_type]
+    else:
+        message = ('Learner archive has unsupported archive_type: '
+                   '{archive_type}').format(archive_type=archive_type)
+        log.error(message)
+        raise NotImplementedError(message)
+    
+    return controller_type
+
 def check_file_type_supported(file_type):
     '''
     Checks whether the file type is supported

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -207,7 +207,23 @@ def get_dict_from_file(filename,file_type):
     else:
         raise ValueError
     return dictionary
+
+def get_file_type(filename):
+    '''
+    Get the file type of a file from the extension in its filename.
     
+    Args:
+        filename (String): The filename including extension, and optionally
+            including path, from which to extract the file type.
+
+    Returns:
+        file_type (String): The file's type, inferred from its extension. The
+            type does NOT include a leading period.
+    '''
+    _, file_type = os.path.splitext(filename)
+    file_type = file_type[1:]  # Remove leading '.'.
+    return file_type
+
 def check_file_type_supported(file_type):
     '''
     Checks whether the file type is supported

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -58,9 +58,9 @@ def show_all_default_visualizations_from_archive(controller_filename,
                                                  learner_filename,
                                                  controller_type=None,
                                                  show_plots=True,
-                                                 controller_visualization_args={},
-                                                 learner_visualization_args={},
-                                                 learner_visualizer_init_args={}):
+                                                 controller_visualization_kwargs={},
+                                                 learner_visualization_kwargs={},
+                                                 learner_visualizer_init_kwargs={}):
     '''
     Plots all visualizations available for a controller and its learner from their archives.
     
@@ -78,11 +78,11 @@ def show_all_default_visualizations_from_archive(controller_filename,
             Default None.
         show_plots (bool): Determine whether to run plt.show() at the end or
             not. For debugging. Default True.
-        controller_visualization_args (dict): Keyword arguments to pass to the
+        controller_visualization_kwargs (dict): Keyword arguments to pass to the
             controller visualizer's create_visualizations() method. Default {}.
-        learner_visualization_args (dict): Keyword arguments to pass to the
+        learner_visualization_kwargs (dict): Keyword arguments to pass to the
             learner visualizer's create_visualizations() method. Default {}.
-        learner_visualizer_init_args (dict): Keyword arguments to pass to the
+        learner_visualizer_init_kwargs (dict): Keyword arguments to pass to the
             learner visualizer's __init__() method. Default {}.
     '''
     log = logging.getLogger(__name__)
@@ -92,14 +92,14 @@ def show_all_default_visualizations_from_archive(controller_filename,
     log.debug('Creating controller visualizations.')
     create_controller_visualizations(
         controller_filename,
-        **controller_visualization_args,
+        **controller_visualization_kwargs,
     )
     
     # Create visualizations for the learner archive.
     create_learner_visualizations(
         learner_filename,
-        learner_visualization_args=learner_visualization_args,
-        learner_visualizer_init_args=learner_visualizer_init_args,
+        learner_visualization_kwargs=learner_visualization_kwargs,
+        learner_visualizer_init_kwargs=learner_visualizer_init_kwargs,
     )
 
     log.info('Showing visualizations, close all to end MLOOP.')
@@ -150,8 +150,8 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
     return visualizer
 
 def create_learner_visualizations(filename,
-                                  learner_visualization_args={},
-                                  learner_visualizer_init_args={}):
+                                  learner_visualization_kwargs={},
+                                  learner_visualizer_init_kwargs={}):
     '''
     Runs the plots for a learner archive file.
     
@@ -159,16 +159,16 @@ def create_learner_visualizations(filename,
         filename (str): Filename for the learner archive. 
     
     Keyword Args:
-        learner_visualization_args (dict): Keyword arguments to pass to the
+        learner_visualization_kwargs (dict): Keyword arguments to pass to the
             learner visualizer's create_visualizations() method. Default {}.
-        learner_visualizer_init_args (dict): Keyword arguments to pass to the
+        learner_visualizer_init_kwargs (dict): Keyword arguments to pass to the
             learner visualizer's __init__() method. Default {}.
     '''
     visualizer = create_learner_visualizer_from_archive(
         filename,
-        **learner_visualizer_init_args,
+        **learner_visualizer_init_kwargs,
     )
-    visualizer.create_visualizations(**learner_visualization_args)
+    visualizer.create_visualizations(**learner_visualization_kwargs)
 
 def _color_from_controller_name(controller_name):
     '''

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -98,7 +98,7 @@ def show_all_default_visualizations_from_archive(controller_filename, learner_fi
     if show_plots:
         plt.show()
 
-def create_learner_visualizer_from_archive(filename, file_type=None, controller_type=None, **kwargs):
+def create_learner_visualizer_from_archive(filename, controller_type=None, **kwargs):
     '''
     Create an instance of the appropriate visualizer class for a learner archive.
     
@@ -106,47 +106,36 @@ def create_learner_visualizer_from_archive(filename, file_type=None, controller_
         filename (String): Filename of the learner archive.
     
     Keyword Args:
-        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
-            for text. If set to None, then the type will be determined from the
-            extension in filename. Default None.
         controller_type (String): The type of controller used during the
             optimization that created the provided learner archive. Options
             include 'gaussian_process', 'neural_net', and
             'differential_evolution'. If set to None, then controller_type will
             be determined automatically from the archive. Default None.
-        **kwargs: Additional keyword arguments are passed to the calll to the
-            visualizer's __init__() method.
+        **kwargs: Additional keyword arguments are passed to the visualizer's
+            __init__() method.
 
     Returns:
         visualizer: An instance of the appropriate visualizer class for plotting
             data from filename.
     '''
-    # Automatically determine file_type if necessary.
-    if file_type is None:
-        file_type = mlu.get_file_type(filename)
-    
-    # Ensure file_type is supported.
-    log = logging.getLogger(__name__)
-    if not mlu.check_file_type_supported(file_type):
-        log.error('File type not supported: ' + repr(file_type))
-    
     # Automatically determine controller_type if necessary.
     if controller_type is None:
-        learner_dict = mlu.get_dict_from_file(filename, file_type)
-        controller_type = learner_dict['archive_type']
+        controller_type = mlu.get_controller_type_from_learner_archive(filename)
         
     # Create an instance of the appropriate visualizer class for the archive.
+    log = logging.getLogger(__name__)
     if controller_type == 'neural_net':
         log.debug('Creating neural net visualizer.')
-        visualizer = NeuralNetVisualizer(filename, file_type, **kwargs)
+        visualizer = NeuralNetVisualizer(filename, **kwargs)
     elif controller_type == 'gaussian_process':
         log.debug('Creating gaussian process visualizer.')
-        visualizer = GaussianProcessVisualizer(filename, file_type, **kwargs)
+        visualizer = GaussianProcessVisualizer(filename, **kwargs)
     elif controller_type == 'differential_evolution':
         log.debug('Creating differential evolution visualizer.')
-        visualizer = DifferentialEvolutionVisualizer(filename, file_type, **kwargs)
+        visualizer = DifferentialEvolutionVisualizer(filename, **kwargs)
     else:
-        message = 'create_learner_visualizer_from_archive() not implemented for type: ' + controller_type
+        message = ('create_learner_visualizer_from_archive() not implemented '
+                   'for type: {type_}.').format(type_=controller_type)
         log.error(message)
         raise ValueError(message)
     

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -428,8 +428,7 @@ class ControllerVisualizer():
 
 def create_differential_evolution_learner_visualizations(filename,
                                                          file_type=None,
-                                                         plot_params_vs_generations=True,
-                                                         plot_costs_vs_generations=True):
+                                                         **kwargs):
     '''
     Runs the plots from a differential evolution learner file.
     
@@ -440,14 +439,11 @@ def create_differential_evolution_learner_visualizations(filename,
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
-        plot_params_generations (Optional [bool]): If True plot parameters vs generations, else do not. Default True. 
-        plot_costs_generations (Optional [bool]): If True plot costs vs generations, else do not. Default True. 
+        **kwargs: Additional keyword arguments are passed to the visualizer's
+            create_visualizations() method.
     '''
     visualization = DifferentialEvolutionVisualizer(filename, file_type=file_type)
-    if plot_params_vs_generations:
-        visualization.plot_params_vs_generations()
-    if plot_costs_vs_generations:
-        visualization.plot_costs_vs_generations()
+    visualization.create_visualizations(**kwargs)
 
 class DifferentialEvolutionVisualizer():
     '''
@@ -498,6 +494,23 @@ class DifferentialEvolutionVisualizer():
         self.gen_numbers = np.arange(1,self.num_generations+1)
         self.param_colors = _color_list_from_num_of_params(self.num_params)
         self.gen_plot = np.array([np.full(self.num_population_members, ind, dtype=int) for ind in self.gen_numbers]).flatten()
+        
+    def create_visualizations(self,
+                              plot_params_vs_generations=True,
+                              plot_costs_vs_generations=True):
+        '''
+        Runs the plots from a differential evolution learner file.
+            
+        Keyword Args:
+            plot_params_generations (Optional [bool]): If True plot parameters
+                vs generations, else do not. Default True. 
+            plot_costs_generations (Optional [bool]): If True plot costs vs
+                generations, else do not. Default True. 
+        '''
+        if plot_params_vs_generations:
+            self.plot_params_vs_generations()
+        if plot_costs_vs_generations:
+            self.plot_costs_vs_generations()
         
     def plot_costs_vs_generations(self):
         '''

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -53,7 +53,7 @@ def show_all_default_visualizations(controller, show_plots=True):
     if show_plots:
         plt.show()
 
-def show_all_default_visualizations_from_archive(controller_filename, learner_filename, controller_type, show_plots=True):
+def show_all_default_visualizations_from_archive(controller_filename, learner_filename, controller_type=None, show_plots=True):
     '''
     Plots all visualizations available for a controller and it's learner from their archives.
     
@@ -62,17 +62,26 @@ def show_all_default_visualizations_from_archive(controller_filename, learner_fi
             controller archive.
         learner_filename (str): The filename, inlcuding path, of the learner
             archive.
-        controller_type (str): The filename, type of the learner, e.g.
-            'gaussian_process', 'neural_net', or 'differential_evolution'.
         
     Keyword Args:
-        show_plots (Controller): Determine whether to run plt.show() at the end or not. For debugging. 
+        controller_type (str): The value of controller_type type used in the
+            optimization corresponding to the learner learner archive, e.g.
+            'gaussian_process', 'neural_net', or 'differential_evolution'. If
+            set to None then controller_type will be determined automatically.
+            Default None.
+        show_plots (Controller): Determine whether to run plt.show() at the end
+            or not. For debugging. 
     '''
+    # Automatically determine controller_type if necessary.
+    if controller_type is None:
+        controller_type = mlu.get_controller_type_from_learner_archive(
+            learner_filename,
+        )
     log = logging.getLogger(__name__)
     configure_plots()
     log.debug('Creating controller visualizations.')
-    controller_file_type = controller_filename.split(".")[-1]
-    learner_file_type = learner_filename.split(".")[-1]
+    controller_file_type = mlu.get_file_type(controller_filename)
+    learner_file_type = mlu.get_file_type(learner_filename)
     create_controller_visualizations(controller_filename, file_type=controller_file_type)
 
     if controller_type == 'neural_net':

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -191,9 +191,7 @@ def configure_plots():
     
 def create_controller_visualizations(filename,
                                     file_type=None,
-                                    plot_cost_vs_run=True,
-                                    plot_parameters_vs_run=True,
-                                    plot_parameters_vs_cost=True):
+                                    **kwargs):
     '''
     Runs the plots for a controller file.
     
@@ -204,17 +202,11 @@ def create_controller_visualizations(filename,
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
-        plot_cost_vs_run (Optional [bool]): If True plot cost versus run number, else do not. Default True. 
-        plot_parameters_vs_run (Optional [bool]): If True plot parameters versus run number, else do not. Default True. 
-        plot_parameters_vs_cost (Optional [bool]): If True plot parameters versus cost number, else do not. Default True. 
+        **kwargs: Additional keyword arguments are passed to the visualizer's
+            create_visualizations() method.
     '''
     visualization = ControllerVisualizer(filename,file_type=file_type)
-    if plot_cost_vs_run:
-        visualization.plot_cost_vs_run()
-    if plot_parameters_vs_run:
-        visualization.plot_parameters_vs_run()
-    if plot_parameters_vs_cost:
-       visualization.plot_parameters_vs_cost()
+    visualization.create_visualizations(**kwargs)
 
 class ControllerVisualizer():
     '''
@@ -273,6 +265,28 @@ class ControllerVisualizer():
         self.in_numbers = np.arange(1,self.num_in_costs+1)
         self.out_numbers = np.arange(1,self.num_out_params+1)
         self.param_numbers = np.arange(self.num_params)
+    
+    def create_visualizations(self,
+                              plot_cost_vs_run=True,
+                              plot_parameters_vs_run=True,
+                              plot_parameters_vs_cost=True):
+        '''
+        Runs the plots for a controller file.
+        
+        Keyword Args:
+            plot_cost_vs_run (Optional [bool]): If True plot cost versus run
+                number, else do not. Default True. 
+            plot_parameters_vs_run (Optional [bool]): If True plot parameters
+                versus run number, else do not. Default True. 
+            plot_parameters_vs_cost (Optional [bool]): If True plot parameters
+                versus cost number, else do not. Default True. 
+        '''
+        if plot_cost_vs_run:
+            self.plot_cost_vs_run()
+        if plot_parameters_vs_run:
+            self.plot_parameters_vs_run()
+        if plot_parameters_vs_cost:
+            self.plot_parameters_vs_cost()
         
     def plot_cost_vs_run(self):
         '''

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -62,7 +62,7 @@ def show_all_default_visualizations_from_archive(controller_filename,
                                                  learner_visualization_args={},
                                                  learner_visualizer_init_args={}):
     '''
-    Plots all visualizations available for a controller and it's learner from their archives.
+    Plots all visualizations available for a controller and its learner from their archives.
     
     Args:
         controller_filename (str): The filename, inlcuding path, of the

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -856,9 +856,9 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             
 def create_neural_net_learner_visualizations(filename,
                                              file_type=None,
-                                             plot_cross_sections=True):
+                                             **kwargs):
     '''
-    Creates plots from a neural nets learner file.
+    Creates plots from a neural net's learner file.
     
     Args:
         filename (Optional [string]): Filename for the neural net archive. Must provide datetime or filename. Default None.
@@ -867,15 +867,11 @@ def create_neural_net_learner_visualizations(filename,
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
-        plot_cross_sections (Optional [bool]): If True plot predicted landscape
-            cross sections, else do not. Default True. 
+        **kwargs: Additional keyword arguments are passed to the visualizer's
+            create_visualizations() method.
     '''
     visualization = NeuralNetVisualizer(filename, file_type=file_type)
-    if plot_cross_sections:
-        visualization.do_cross_sections()
-    visualization.plot_surface()
-    visualization.plot_density_surface()
-    visualization.plot_losses()
+    visualization.create_visualizations(**kwargs)
 
             
 class NeuralNetVisualizer(mll.NeuralNetLearner):
@@ -925,6 +921,20 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         Overides the GaussianProcessLearner multiprocessor run routine. Does nothing but makes a warning.
         '''
         self.log.warning('You should not have executed start() from the GaussianProcessVisualizer. It is not intended to be used as a independent process. Ending.')
+    
+    def create_visualizations(self, plot_cross_sections=True):
+        '''
+        Creates plots from a neural net's learner file.
+            
+        Keyword Args:
+            plot_cross_sections (Optional [bool]): If True plot predicted
+                landscape cross sections, else do not. Default True. 
+        '''
+        if plot_cross_sections:
+            self.do_cross_sections()
+        self.plot_surface()
+        self.plot_density_surface()
+        self.plot_losses()
     
       
     def return_cross_sections(self, points=100, cross_section_center=None):

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -54,6 +54,20 @@ def show_all_default_visualizations(controller, show_plots=True):
         plt.show()
 
 def show_all_default_visualizations_from_archive(controller_filename, learner_filename, controller_type, show_plots=True):
+    '''
+    Plots all visualizations available for a controller and it's learner from their archives.
+    
+    Args:
+        controller_filename (str): The filename, inlcuding path, of the
+            controller archive.
+        learner_filename (str): The filename, inlcuding path, of the learner
+            archive.
+        controller_type (str): The filename, type of the learner, e.g.
+            'gaussian_process', 'neural_net', or 'differential_evolution'.
+        
+    Keyword Args:
+        show_plots (Controller): Determine whether to run plt.show() at the end or not. For debugging. 
+    '''
     log = logging.getLogger(__name__)
     configure_plots()
     log.debug('Creating controller visualizations.')
@@ -64,6 +78,16 @@ def show_all_default_visualizations_from_archive(controller_filename, learner_fi
     if controller_type == 'neural_net':
         log.debug('Creating neural net visualizations.')
         create_neural_net_learner_visualizations(
+            learner_filename,
+            file_type=learner_file_type)
+    elif controller_type == 'gaussian_process':
+        log.debug('Creating gaussian process visualizations.')
+        create_gaussian_process_learner_visualizations(
+            learner_filename,
+            file_type=learner_file_type)
+    elif controller_type == 'differential_evolution':
+        log.debug('Creating differential evolution visualizations.')
+        create_differential_evolution_learner_visualizations(
             learner_filename,
             file_type=learner_file_type)
     else:

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -53,7 +53,13 @@ def show_all_default_visualizations(controller, show_plots=True):
     if show_plots:
         plt.show()
 
-def show_all_default_visualizations_from_archive(controller_filename, learner_filename, controller_type=None, show_plots=True):
+def show_all_default_visualizations_from_archive(controller_filename,
+                                                 learner_filename,
+                                                 controller_type=None,
+                                                 show_plots=True,
+                                                 controller_visualization_args={},
+                                                 learner_visualization_args={},
+                                                 learner_visualizer_init_args={}):
     '''
     Plots all visualizations available for a controller and it's learner from their archives.
     
@@ -69,31 +75,31 @@ def show_all_default_visualizations_from_archive(controller_filename, learner_fi
             'gaussian_process', 'neural_net', or 'differential_evolution'. If
             set to None then controller_type will be determined automatically.
             Default None.
-        show_plots (Controller): Determine whether to run plt.show() at the end
-            or not. For debugging. 
+        show_plots (bool): Determine whether to run plt.show() at the end or
+            not. For debugging. Default True.
+        controller_visualization_args (dict): Keyword arguments to pass to the
+            controller visualizer's create_visualizations() method. Default {}.
+        learner_visualization_args (dict): Keyword arguments to pass to the
+            learner visualizer's create_visualizations() method. Default {}.
+        learner_visualizer_init_args (dict): Keyword arguments to pass to the
+            learner visualizer's __init__() method. Default {}.
     '''
-    # Automatically determine controller_type if necessary.
-    if controller_type is None:
-        controller_type = mlu.get_controller_type_from_learner_archive(
-            learner_filename,
-        )
     log = logging.getLogger(__name__)
     configure_plots()
+    
+    # Create visualizations for the controller archive.
     log.debug('Creating controller visualizations.')
-    create_controller_visualizations(controller_filename)
-
-    if controller_type == 'neural_net':
-        log.debug('Creating neural net visualizations.')
-        create_neural_net_learner_visualizations(learner_filename)
-    elif controller_type == 'gaussian_process':
-        log.debug('Creating gaussian process visualizations.')
-        create_gaussian_process_learner_visualizations(learner_filename)
-    elif controller_type == 'differential_evolution':
-        log.debug('Creating differential evolution visualizations.')
-        create_differential_evolution_learner_visualizations(learner_filename)
-    else:
-        log.error('show_all_default_visualizations not implemented for type: ' + controller_type)
-        raise ValueError
+    create_controller_visualizations(
+        controller_filename,
+        **controller_visualization_args,
+    )
+    
+    # Create visualizations for the learner archive.
+    create_learner_visualizations(
+        learner_filename,
+        learner_visualization_args=learner_visualization_args,
+        learner_visualizer_init_args=learner_visualizer_init_args,
+    )
 
     log.info('Showing visualizations, close all to end MLOOP.')
     if show_plots:
@@ -141,6 +147,27 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
         raise ValueError(message)
     
     return visualizer
+
+def create_learner_visualizations(filename,
+                                  learner_visualization_args={},
+                                  learner_visualizer_init_args={}):
+    '''
+    Runs the plots for a learner archive file.
+    
+    Args:
+        filename (str): Filename for the learner archive. 
+    
+    Keyword Args:
+        learner_visualization_args (dict): Keyword arguments to pass to the
+            learner visualizer's create_visualizations() method. Default {}.
+        learner_visualizer_init_args (dict): Keyword arguments to pass to the
+            learner visualizer's __init__() method. Default {}.
+    '''
+    visualizer = create_learner_visualizer_from_archive(
+        filename,
+        **learner_visualizer_init_args,
+    )
+    visualizer.create_visualizations(**learner_visualization_args)
 
 def _color_from_controller_name(controller_name):
     '''

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -577,8 +577,7 @@ class DifferentialEvolutionVisualizer():
         
 def create_gaussian_process_learner_visualizations(filename,
                                                    file_type=None,
-                                                   plot_cross_sections=True,
-                                                   plot_hyperparameters_vs_run=True):
+                                                   **kwargs):
     '''
     Runs the plots from a gaussian process learner file.
     
@@ -589,17 +588,11 @@ def create_gaussian_process_learner_visualizations(filename,
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
-        plot_cross_sections (Optional [bool]): If True plot predicted landscape
-            cross sections, else do not. Default True. 
-        plot_hyperparameters_vs_run (Optional [bool]): If True plot fitted
-            hyperparameters as a function of run number, else do not. Default
-            True.
+        **kwargs: Additional keyword arguments are passed to the visualizer's
+            create_visualizations() method.
     '''
     visualization = GaussianProcessVisualizer(filename, file_type=file_type)
-    if plot_cross_sections:
-        visualization.plot_cross_sections()
-    if plot_hyperparameters_vs_run:
-        visualization.plot_hyperparameters_vs_run()
+    visualization.create_visualizations(**kwargs)
     
 class GaussianProcessVisualizer(mll.GaussianProcessLearner):
     '''
@@ -694,6 +687,24 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         cost_arrays = self.cost_scaler.inverse_transform(np.array(cost_arrays))
         uncertainty_arrays = np.array(uncertainty_arrays)
         return (cross_parameter_arrays,cost_arrays,uncertainty_arrays) 
+    
+    def create_visualizations(self,
+                              plot_cross_sections=True,
+                              plot_hyperparameters_vs_run=True):
+        '''
+        Runs the plots from a gaussian process learner file.
+            
+        Keyword Args:
+            plot_cross_sections (Optional [bool]): If True plot predicted
+                landscape cross sections, else do not. Default True. 
+            plot_hyperparameters_vs_run (Optional [bool]): If True plot fitted
+                hyperparameters as a function of run number, else do not.
+                Default True.
+        '''
+        if plot_cross_sections:
+            self.plot_cross_sections()
+        if plot_hyperparameters_vs_run:
+            self.plot_hyperparameters_vs_run()
     
     def _ensure_parameter_subset_valid(self, parameter_subset):
         _ensure_parameter_subset_valid(self, parameter_subset)

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -58,9 +58,9 @@ def show_all_default_visualizations_from_archive(controller_filename,
                                                  learner_filename,
                                                  controller_type=None,
                                                  show_plots=True,
-                                                 controller_visualization_kwargs={},
-                                                 learner_visualization_kwargs={},
-                                                 learner_visualizer_init_kwargs={}):
+                                                 controller_visualization_kwargs=None,
+                                                 learner_visualization_kwargs=None,
+                                                 learner_visualizer_init_kwargs=None):
     '''
     Plots all visualizations available for a controller and its learner from their archives.
     
@@ -79,12 +79,19 @@ def show_all_default_visualizations_from_archive(controller_filename,
         show_plots (bool): Determine whether to run plt.show() at the end or
             not. For debugging. Default True.
         controller_visualization_kwargs (dict): Keyword arguments to pass to the
-            controller visualizer's create_visualizations() method. Default {}.
+            controller visualizer's create_visualizations() method. If set to
+            None, no additional keyword arguments will be passed. Default None.
         learner_visualization_kwargs (dict): Keyword arguments to pass to the
-            learner visualizer's create_visualizations() method. Default {}.
+            learner visualizer's create_visualizations() method.  If set to
+            None, no additional keyword arguments will be passed. Default None.
         learner_visualizer_init_kwargs (dict): Keyword arguments to pass to the
-            learner visualizer's __init__() method. Default {}.
+            learner visualizer's __init__() method. If set to None, no
+            additional keyword arguments will be passed. Default None.
     '''
+    # Set default value for controller_visualization_kwargs if necessary
+    if controller_visualization_kwargs is None:
+        controller_visualization_kwargs = {}
+    
     log = logging.getLogger(__name__)
     configure_plots()
     
@@ -150,8 +157,8 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
     return visualizer
 
 def create_learner_visualizations(filename,
-                                  learner_visualization_kwargs={},
-                                  learner_visualizer_init_kwargs={}):
+                                  learner_visualization_kwargs=None,
+                                  learner_visualizer_init_kwargs=None):
     '''
     Runs the plots for a learner archive file.
     
@@ -160,10 +167,19 @@ def create_learner_visualizations(filename,
     
     Keyword Args:
         learner_visualization_kwargs (dict): Keyword arguments to pass to the
-            learner visualizer's create_visualizations() method. Default {}.
+            learner visualizer's create_visualizations() method.  If set to
+            None, no additional keyword arguments will be passed. Default None.
         learner_visualizer_init_kwargs (dict): Keyword arguments to pass to the
-            learner visualizer's __init__() method. Default {}.
+            learner visualizer's __init__() method. If set to None, no
+            additional keyword arguments will be passed. Default None.
     '''
+    # Set default values as necessary.
+    if learner_visualization_kwargs is None:
+        learner_visualization_kwargs = {}
+    if learner_visualizer_init_kwargs is None:
+        learner_visualizer_init_kwargs = {}
+    
+    # Create a visualizer and have it make the plots.
     visualizer = create_learner_visualizer_from_archive(
         filename,
         **learner_visualizer_init_kwargs,

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -31,7 +31,8 @@ def show_all_default_visualizations(controller, show_plots=True):
         controller (Controller): The controller to extract plots from
         
     Keyword Args:
-        show_plots (Controller): Determine whether to run plt.show() at the end or not. For debugging. 
+        show_plots (bool): Determine whether to run plt.show() at the end or
+            not. For debugging. Default True.
     '''
     log = logging.getLogger(__name__)
     configure_plots()
@@ -223,7 +224,7 @@ def create_controller_visualizations(filename,
     Runs the plots for a controller file.
     
     Args:
-        filename (Optional [string]): Filename for the controller archive. 
+        filename (String): Filename of the controller archive.
     
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
@@ -460,7 +461,8 @@ def create_differential_evolution_learner_visualizations(filename,
     Runs the plots from a differential evolution learner file.
     
     Args:
-        filename (Optional [string]): Filename for the differential evolution archive. Must provide datetime or filename. Default None.
+        filename (String): Filename for the differential evolution learner
+            archive.
         
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
@@ -609,7 +611,7 @@ def create_gaussian_process_learner_visualizations(filename,
     Runs the plots from a gaussian process learner file.
     
     Args:
-        filename (Optional [string]): Filename for the gaussian process archive. Must provide datetime or filename. Default None.
+        filename (String): Filename for the gaussian process learner archive.
         
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
@@ -888,7 +890,7 @@ def create_neural_net_learner_visualizations(filename,
     Creates plots from a neural net's learner file.
     
     Args:
-        filename (Optional [string]): Filename for the neural net archive. Must provide datetime or filename. Default None.
+        filename (String): Filename for the neural net learner archive.
         
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -121,7 +121,7 @@ def create_learner_visualizer_from_archive(filename, file_type=None, controller_
         visualizer: An instance of the appropriate visualizer class for plotting
             data from filename.
     '''
-    # Autmatically determine file_type if necessary.
+    # Automatically determine file_type if necessary.
     if file_type is None:
         file_type = mlu.get_file_type(filename)
     
@@ -229,22 +229,27 @@ class ControllerVisualizer():
     ControllerVisualizer creates figures from a Controller Archive. 
     
     Args:
-        filename (String): Filename of the GaussianProcessLearner archive.
+        filename (String): Filename of the controller archive.
     
     Keyword Args:
-        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt' for text. Default 'pkl'. 
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
     
     '''
-    def __init__(self, filename, 
-                 file_type ='pkl', 
+    def __init__(self, filename,
+                 file_type=None,
                  **kwargs):
         
         self.log = logging.getLogger(__name__)
         
         self.filename = str(filename)
+        # Automatically determine file_type if necessary.
+        if file_type is None:
+            file_type = mlu.get_file_type(self.filename)
         self.file_type = str(file_type)
         if not mlu.check_file_type_supported(self.file_type):
-            self.log.error('GP training file type not supported' + repr(self.file_type))
+            self.log.error('File type not supported: ' + repr(self.file_type))
         controller_dict = mlu.get_dict_from_file(self.filename, self.file_type)
             
         self.archive_type = controller_dict['archive_type']
@@ -444,19 +449,24 @@ class DifferentialEvolutionVisualizer():
         filename (String): Filename of the DifferentialEvolutionVisualizer archive.
     
     Keyword Args:
-        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt' for text. Default 'pkl'. 
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
     
     '''
-    def __init__(self, filename, 
-                 file_type ='pkl', 
+    def __init__(self, filename,
+                 file_type=None,
                  **kwargs):
         
         self.log = logging.getLogger(__name__)
         
         self.filename = str(filename)
+        # Automatically determine file_type if necessary.
+        if file_type is None:
+            file_type = mlu.get_file_type(self.filename)
         self.file_type = str(file_type)
         if not mlu.check_file_type_supported(self.file_type):
-            self.log.error('GP training file type not supported' + repr(self.file_type))
+            self.log.error('File type not supported: ' + repr(self.file_type))
         learner_dict = mlu.get_dict_from_file(self.filename, self.file_type)
         
         if 'archive_type' in learner_dict and not (learner_dict['archive_type'] == 'differential_evolution'):
@@ -572,11 +582,13 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         filename (String): Filename of the GaussianProcessLearner archive.
     
     Keyword Args:
-        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt' for text. Default 'pkl'. 
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
       
     '''
     
-    def __init__(self, filename, file_type = 'pkl', **kwargs):
+    def __init__(self, filename, file_type=None, **kwargs):
         
         super(GaussianProcessVisualizer, self).__init__(gp_training_filename = filename,
                                                         gp_training_file_type = file_type,
@@ -830,14 +842,15 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
     NeuralNetVisualizer extends of NeuralNetLearner, designed not to be used as a learner, but to instead post process a NeuralNetLearner archive file and produce useful data for visualization of the state of the learner. 
     
     Args:
-        filename (String): Filename of the GaussianProcessLearner archive.
+        filename (String): Filename of the NeuralNetLearner archive.
     
     Keyword Args:
-        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt' for text. Default 'pkl'. 
-      
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
     '''
     
-    def __init__(self, filename, file_type = 'pkl', **kwargs):
+    def __init__(self, filename, file_type = None, **kwargs):
         
         
         

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -98,6 +98,60 @@ def show_all_default_visualizations_from_archive(controller_filename, learner_fi
     if show_plots:
         plt.show()
 
+def create_learner_visualizer_from_archive(filename, file_type=None, controller_type=None, **kwargs):
+    '''
+    Create an instance of the appropriate visualizer class for a learner archive.
+    
+    Args:
+        filename (String): Filename of the learner archive.
+    
+    Keyword Args:
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
+        controller_type (String): The type of controller used during the
+            optimization that created the provided learner archive. Options
+            include 'gaussian_process', 'neural_net', and
+            'differential_evolution'. If set to None, then controller_type will
+            be determined automatically from the archive. Default None.
+        **kwargs: Additional keyword arguments are passed to the calll to the
+            visualizer's __init__() method.
+
+    Returns:
+        visualizer: An instance of the appropriate visualizer class for plotting
+            data from filename.
+    '''
+    # Autmatically determine file_type if necessary.
+    if file_type is None:
+        file_type = mlu.get_file_type(filename)
+    
+    # Ensure file_type is supported.
+    log = logging.getLogger(__name__)
+    if not mlu.check_file_type_supported(file_type):
+        log.error('File type not supported: ' + repr(file_type))
+    
+    # Automatically determine controller_type if necessary.
+    if controller_type is None:
+        learner_dict = mlu.get_dict_from_file(filename, file_type)
+        controller_type = learner_dict['archive_type']
+        
+    # Create an instance of the appropriate visualizer class for the archive.
+    if controller_type == 'neural_net':
+        log.debug('Creating neural net visualizer.')
+        visualizer = NeuralNetVisualizer(filename, file_type, **kwargs)
+    elif controller_type == 'gaussian_process':
+        log.debug('Creating gaussian process visualizer.')
+        visualizer = GaussianProcessVisualizer(filename, file_type, **kwargs)
+    elif controller_type == 'differential_evolution':
+        log.debug('Creating differential evolution visualizer.')
+        visualizer = DifferentialEvolutionVisualizer(filename, file_type, **kwargs)
+    else:
+        message = 'create_learner_visualizer_from_archive() not implemented for type: ' + controller_type
+        log.error(message)
+        raise ValueError(message)
+    
+    return visualizer
+
 def _color_from_controller_name(controller_name):
     '''
     Gives a color (as a number betweeen zero an one) corresponding to each controller name string.

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -80,25 +80,17 @@ def show_all_default_visualizations_from_archive(controller_filename, learner_fi
     log = logging.getLogger(__name__)
     configure_plots()
     log.debug('Creating controller visualizations.')
-    controller_file_type = mlu.get_file_type(controller_filename)
-    learner_file_type = mlu.get_file_type(learner_filename)
-    create_controller_visualizations(controller_filename, file_type=controller_file_type)
+    create_controller_visualizations(controller_filename)
 
     if controller_type == 'neural_net':
         log.debug('Creating neural net visualizations.')
-        create_neural_net_learner_visualizations(
-            learner_filename,
-            file_type=learner_file_type)
+        create_neural_net_learner_visualizations(learner_filename)
     elif controller_type == 'gaussian_process':
         log.debug('Creating gaussian process visualizations.')
-        create_gaussian_process_learner_visualizations(
-            learner_filename,
-            file_type=learner_file_type)
+        create_gaussian_process_learner_visualizations(learner_filename)
     elif controller_type == 'differential_evolution':
         log.debug('Creating differential evolution visualizations.')
-        create_differential_evolution_learner_visualizations(
-            learner_filename,
-            file_type=learner_file_type)
+        create_differential_evolution_learner_visualizations(learner_filename)
     else:
         log.error('show_all_default_visualizations not implemented for type: ' + controller_type)
         raise ValueError
@@ -198,7 +190,7 @@ def configure_plots():
     mpl.rcParams['legend.fontsize']= 'medium'
     
 def create_controller_visualizations(filename,
-                                    file_type='pkl',
+                                    file_type=None,
                                     plot_cost_vs_run=True,
                                     plot_parameters_vs_run=True,
                                     plot_parameters_vs_cost=True):
@@ -209,7 +201,9 @@ def create_controller_visualizations(filename,
         filename (Optional [string]): Filename for the controller archive. 
     
     Keyword Args:
-        file_type (Optional [string]): File type 'pkl' pickle, 'mat' matlab or 'txt' text.
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
         plot_cost_vs_run (Optional [bool]): If True plot cost versus run number, else do not. Default True. 
         plot_parameters_vs_run (Optional [bool]): If True plot parameters versus run number, else do not. Default True. 
         plot_parameters_vs_cost (Optional [bool]): If True plot parameters versus cost number, else do not. Default True. 
@@ -419,7 +413,7 @@ class ControllerVisualizer():
         plt.legend(artists,[str(x) for x in parameter_subset], loc=legend_loc)
 
 def create_differential_evolution_learner_visualizations(filename,
-                                                         file_type='pkl',
+                                                         file_type=None,
                                                          plot_params_vs_generations=True,
                                                          plot_costs_vs_generations=True):
     '''
@@ -429,7 +423,9 @@ def create_differential_evolution_learner_visualizations(filename,
         filename (Optional [string]): Filename for the differential evolution archive. Must provide datetime or filename. Default None.
         
     Keyword Args:
-        file_type (Optional [string]): File type 'pkl' pickle, 'mat' matlab or 'txt' text.
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
         plot_params_generations (Optional [bool]): If True plot parameters vs generations, else do not. Default True. 
         plot_costs_generations (Optional [bool]): If True plot costs vs generations, else do not. Default True. 
     '''
@@ -553,7 +549,7 @@ class DifferentialEvolutionVisualizer():
         plt.legend(artists,[str(x) for x in parameter_subset],loc=legend_loc)
         
 def create_gaussian_process_learner_visualizations(filename,
-                                                   file_type='pkl',
+                                                   file_type=None,
                                                    plot_cross_sections=True,
                                                    plot_hyperparameters_vs_run=True):
     '''
@@ -563,8 +559,14 @@ def create_gaussian_process_learner_visualizations(filename,
         filename (Optional [string]): Filename for the gaussian process archive. Must provide datetime or filename. Default None.
         
     Keyword Args:
-        file_type (Optional [string]): File type 'pkl' pickle, 'mat' matlab or 'txt' text.
-        plot_cross_sections (Optional [bool]): If True plot predict landscape cross sections, else do not. Default True. 
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
+        plot_cross_sections (Optional [bool]): If True plot predicted landscape
+            cross sections, else do not. Default True. 
+        plot_hyperparameters_vs_run (Optional [bool]): If True plot fitted
+            hyperparameters as a function of run number, else do not. Default
+            True.
     '''
     visualization = GaussianProcessVisualizer(filename, file_type=file_type)
     if plot_cross_sections:
@@ -815,7 +817,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             plt.title('GP Learner: Noise level vs fit number.')
             
 def create_neural_net_learner_visualizations(filename,
-                                             file_type='pkl',
+                                             file_type=None,
                                              plot_cross_sections=True):
     '''
     Creates plots from a neural nets learner file.
@@ -824,8 +826,11 @@ def create_neural_net_learner_visualizations(filename,
         filename (Optional [string]): Filename for the neural net archive. Must provide datetime or filename. Default None.
         
     Keyword Args:
-        file_type (Optional [string]): File type 'pkl' pickle, 'mat' matlab or 'txt' text.
-        plot_cross_sections (Optional [bool]): If True plot predict landscape cross sections, else do not. Default True. 
+        file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
+            for text. If set to None, then the type will be determined from the
+            extension in filename. Default None.
+        plot_cross_sections (Optional [bool]): If True plot predicted landscape
+            cross sections, else do not. Default True. 
     '''
     visualization = NeuralNetVisualizer(filename, file_type=file_type)
     if plot_cross_sections:


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `create_visualizations()` methods to visualizer classes.
  - They have the same options and perform the same operations as the `create_*_visualizations()` functions but allow for an object-oriented approach.
- Refactor to avoid duplicated code.
- Automatically determine file type for archives.
- Automatically determine controller type for learner archives.
- Add support for remaining learner types to `show_all_default_visualizations_from_archive()`.

Sorry for the size of this one, I ended up doing more refactoring than I had anticipated. A lot of it is just repeating the same changes for each kind of visualizer.

All changes are backwards compatible. Docstrings were added to new functions and methods, and existing docstrings were updated where changes were made.

@qctrl/support, @michaelhush , @charmasaur 
