### PR TITLE
Fixed bug determining file_type in get_dict_from_file().

### DIFF
--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -204,7 +204,7 @@ def get_dict_from_file(filename,file_type=None):
     '''
     # Automatically determine file_type if necessary.
     if file_type is None:
-        file_type = get_file_type(file_type)
+        file_type = get_file_type(filename)
 
     if file_type=='mat':
         dictionary = si.loadmat(filename)


### PR DESCRIPTION
Changes proposed in this pull request:

- One line fix for minor bug that prevents `get_dict_from_file()` from automatically determining `file_type`

I thought I had tested that function with `file_type=None` but I must not have. All of the internal calls to `get_dict_from_file()` specify `file_type` so everything works fine in normal usage. Still worth fixing though.

@qctrl/support @charmasaur 
