### PR TITLE
Update NeuralNetVisualizer.plot_surface()

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1314,7 +1314,6 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         params = [(x,y) for x in param_set[0] for y in param_set[1]]
         costs = self.predict_costs_from_param_array(params)
         ax.scatter([param[0] for param in params], [param[1] for param in params], costs)
-        ax.set_zlim(top=500,bottom=0)
         ax.set_xlabel('x')
         ax.set_ylabel('y')
         ax.set_zlabel('cost')

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1306,6 +1306,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         global figure_counter
         figure_counter += 1
         fig = plt.figure(figure_counter)
+        from mpl_toolkits.mplot3d import Axes3D
         ax = fig.add_subplot(111, projection='3d')
 
         points = 50


### PR DESCRIPTION
Changes proposed in this pull request:

- Add import to `NeuralNetVisualizer.plot_surface()` to make it work.
  - Without the import, that method raises a `ValueError: Unknown projection '3d'` in Matplotlib 3.1.3.
- Removed call to set z axis limits
  - Previously they were always set to be from 0 to 500. Now Matplotlib's automatically scaled values are used.

@qctrl/support @charmasaur 
