### PR TITLE
Plot neural net losses are separately

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2021,5 +2021,5 @@ class NeuralNetLearner(Learner, mp.Process):
     def get_losses(self):
         all_losses = []
         for n in self.neural_net:
-            all_losses += n.get_losses()
+            all_losses.append(n.get_losses())
         return all_losses

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1344,14 +1344,27 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
 
     def plot_losses(self):
         '''
-        Produce a figure of the loss as a function of training run.
+        Produce a figure of the loss as a function of training run for each net.
         '''
         global figure_counter
         figure_counter += 1
         fig = plt.figure(figure_counter)
 
-        losses = self.get_losses()
-        plt.scatter(range(len(losses)), losses)
-        plt.xlabel("Run")
+        all_losses = self.get_losses()
+        
+        # Generate set of distinct colors for plotting.
+        num_nets = len(all_losses)
+        net_colors = _color_list_from_num_of_params(num_nets)
+        
+        artists=[]
+        legend_labels=[]
+        for ind, losses in enumerate(all_losses):
+            color = net_colors[ind]
+            plt.scatter(range(len(losses)), losses, color=color)
+            artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
+            legend_labels.append('Net {net_index}'.format(net_index=ind))
+
+        plt.xlabel("Training Run")
         plt.ylabel("Training cost")
         plt.title('Loss vs training run.')
+        plt.legend(artists, legend_labels, loc=legend_loc)


### PR DESCRIPTION
Changes proposed in this pull request:

- Plot the losses of the different neural nets as difference curves.
  - Previously all of the losses from different neural nets were concatenated into one list, then that list was plotted. That meant that the x-axis didn't quite make sense since it the results were offset horizontally for all but the first net.

Old:
![image](https://user-images.githubusercontent.com/4721629/85514508-1e06ba00-b5ca-11ea-8bbf-52945206ff6c.png)


New:
![image](https://user-images.githubusercontent.com/4721629/85514404-016a8200-b5ca-11ea-8b96-03d9b7d30aaf.png)

Maybe it would be worthwhile to make the y-axis logscale as well?

@qctrl/support @charmasaur 
