### PR TITLE
NeuralNetVisualizer.plot_losses() now plots with a log scale.

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1360,10 +1360,11 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         legend_labels=[]
         for ind, losses in enumerate(all_losses):
             color = net_colors[ind]
-            plt.scatter(range(len(losses)), losses, color=color)
+            plt.plot(range(len(losses)), losses, color=color, marker='o', linestyle='')
             artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
             legend_labels.append('Net {net_index}'.format(net_index=ind))
 
+        plt.yscale('log')
         plt.xlabel("Training Run")
         plt.ylabel("Training cost")
         plt.title('Loss vs training run.')


### PR DESCRIPTION
Changes proposed in this pull request:

- Make the y axis of the neural net's plots of loss vs training run have a log scale.
  - Change first discussed in https://github.com/michaelhush/M-LOOP/pull/61.
  - Had to change `plt.scatter()` to `plt.plot()` to work around matplotlib issue that was originally mentioned here https://github.com/matplotlib/matplotlib/issues/6915 and later subsumed by https://github.com/matplotlib/matplotlib/issues/7413

@qctrl/support @charmasaur 
