### PR TITLE
Support Plotting Hyperparameters when update_hyperparameters is False

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1071,9 +1071,20 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         # Make plot of noise level vs run number if cost has noise. 
         if self.cost_has_noise:
             global figure_counter, run_label, noise_label
+            
+            if self.update_hyperparameters:
+                fit_numbers = self.fit_numbers
+                noise_level_history = self.noise_level_history
+            else:
+                # As in self.plot_hyperparameters_vs_run(), if
+                # update_hyperparameters was set to False, we'll say there were
+                # zero fits and plot the only value.
+                fit_numbers = [0]
+                noise_level_history = [self.noise_level]
+
             figure_counter += 1
             plt.figure(figure_counter)
-            plt.plot(self.fit_numbers,self.noise_level_history,'o',color='k')
+            plt.plot(fit_numbers, noise_level_history,'o',color='k')
             plt.xlabel(run_label)
             plt.ylabel(noise_label)
             plt.title('GP Learner: Noise level vs fit number.')     

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -805,6 +805,11 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             self.scaled_trust_min = self.param_scaler(np.maximum(self.best_params - self.trust_region, self.min_boundary))
             self.scaled_trust_max = self.param_scaler(np.minimum(self.best_params + self.trust_region, self.max_boundary))
         
+        # Record value of update_hyperparameters used for optimization. Note that
+        # self.update_hyperparameters is always set to False here above
+        # regardless of its value during the optimization.
+        self.used_update_hyperparameters = self.training_dict['update_hyperparameters']
+        
     def run(self):
         '''
         Overides the GaussianProcessLearner multiprocessor run routine. Does nothing but makes a warning.
@@ -1020,7 +1025,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         # Get the indices corresponding to the number of fits. If
         # update_hyperparameters was set to False, then we'll say that there
         # were zero fits of the hyperparameters.
-        if self.update_hyperparameters:
+        if self.used_update_hyperparameters:
             fit_numbers = self.fit_numbers
             log_length_scale_history = self.log_length_scale_history
         else:
@@ -1072,7 +1077,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         if self.cost_has_noise:
             global figure_counter, run_label, noise_label
             
-            if self.update_hyperparameters:
+            if self.used_update_hyperparameters:
                 fit_numbers = self.fit_numbers
                 noise_level_history = self.noise_level_history
             else:

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1017,6 +1017,16 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
         
+        # Get the indices corresponding to the number of fits. If
+        # update_hyperparameters was set to False, then we'll say that there
+        # were zero fits of the hyperparameters.
+        if self.update_hyperparameters:
+            fit_numbers = self.fit_numbers
+            log_length_scale_history = self.log_length_scale_history
+        else:
+            fit_numbers = [0]
+            log_length_scale_history = np.log10(np.array([self.length_scale], dtype=float))
+        
         # Generate set of distinct colors for plotting.
         num_params = len(parameter_subset)
         param_colors = _color_list_from_num_of_params(num_params)
@@ -1028,7 +1038,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         if type(self.length_scale) is float:
             # First treat the case of an isotropic kernel with one length scale
             # shared by all parameters.
-            plt.plot(self.fit_numbers,self.log_length_scale_history,'o',color=param_colors[0])
+            plt.plot(fit_numbers, log_length_scale_history,'o',color=param_colors[0])
             plt.title('GP Learner: Log of length scale vs fit number.')
         else:
             # Now treat case of non-isotropic kernels with one length scale per
@@ -1037,7 +1047,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             for ind in range(num_params):
                 param_index = parameter_subset[ind]
                 color = param_colors[ind]
-                plt.plot(self.fit_numbers,self.log_length_scale_history[:,param_index],'o',color=color)
+                plt.plot(fit_numbers, log_length_scale_history[:,param_index],'o',color=color)
                 artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
                 
             legend_labels = mlu._generate_legend_labels(


### PR DESCRIPTION
Previously the `GaussianProcessVisualizer`'s  `plot_hyperparameters_vs_run()` method would error and the `plot_noise_level_vs_run()` method would produce an empty plot if `update_hyperparameters` was set to `False` during a Gaussian process optimization. The root of the issue is that when `update_hyperparameters` is `False`, then there is no history of values for the hyperparameters and noise level. This PR makes those methods behave better in this scenario by having them simply plot one point for each hyperparameter displaying the value specified by the user. This value is plotted at fit index zero on the x-axis since no fit was actually done.

The behavior when `update_hyperparameters` is set to `True` is unchanged.

Changes proposed in this pull request:

- `GaussianProcessVisualizer.plot_hyperparameters_vs_run()` now plots the fixed value(s) provided for the length scale(s) at fit index zero.
- `GaussianProcessVisualizer.plot_noise_level_vs_run()` now plots the noise level at fit index zero.

This produces plots like the following:

![image](https://user-images.githubusercontent.com/4721629/93142563-475c5100-f6b4-11ea-990a-a09c978383e8.png)
![image](https://user-images.githubusercontent.com/4721629/93142576-4e835f00-f6b4-11ea-9ea0-4643ceee94e8.png)

@qctrl/support @charmasaur 
