### PR TITLE
Scaling bugs fixes

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1297,7 +1297,7 @@ class GaussianProcessLearner(Learner, mp.Process):
             self.log.error('Asked to fit GP but no data is in all_costs, all_params or all_uncers.')
             raise ValueError
         self.scaled_costs = self.cost_scaler.fit_transform(self.all_costs[:,np.newaxis])[:,0]
-        self.scaled_uncers = self.all_uncers * self.cost_scaler.scale_
+        self.scaled_uncers = self.all_uncers / self.cost_scaler.scale_
         self.gaussian_process.alpha_ = self.scaled_uncers
         self.gaussian_process.fit(self.all_params,self.scaled_costs)
         
@@ -1434,7 +1434,7 @@ class GaussianProcessLearner(Learner, mp.Process):
                 self.predicted_best_scaled_uncertainty = curr_best_uncer
         
         self.predicted_best_cost = self.cost_scaler.inverse_transform(self.predicted_best_scaled_cost)
-        self.predicted_best_uncertainty = self.predicted_best_scaled_uncertainty / self.cost_scaler.scale_
+        self.predicted_best_uncertainty = self.predicted_best_scaled_uncertainty * self.cost_scaler.scale_
         
         self.archive_dict.update({'predicted_best_parameters':self.predicted_best_parameters,
                                   'predicted_best_scaled_cost':self.predicted_best_scaled_cost,

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -846,17 +846,17 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
                 raise ValueError
         
         cross_parameter_arrays = [ np.linspace(min_p, max_p, points) for (min_p,max_p) in zip(self.min_boundary,self.max_boundary)]
-        cost_arrays = []
-        uncertainty_arrays = []
+        unscaled_cost_arrays = []
+        unscaled_uncertainty_arrays = []
         for ind in range(self.num_params):
             sample_parameters = np.array([cross_section_center for _ in range(points)])
             sample_parameters[:, ind] = cross_parameter_arrays[ind]
             (costs, uncers) = self.gaussian_process.predict(sample_parameters,return_std=True)
-            cost_arrays.append(costs)
-            uncertainty_arrays.append(uncers)
-        cross_parameter_arrays = np.array(cross_parameter_arrays)/self.cost_scaler.scale_
-        cost_arrays = self.cost_scaler.inverse_transform(np.array(cost_arrays))
-        uncertainty_arrays = np.array(uncertainty_arrays)
+            unscaled_cost_arrays.append(costs)
+            unscaled_uncertainty_arrays.append(uncers)
+        cross_parameter_arrays = np.array(cross_parameter_arrays)
+        cost_arrays = self.cost_scaler.inverse_transform(np.array(unscaled_cost_arrays))
+        uncertainty_arrays = np.array(unscaled_uncertainty_arrays) * self.cost_scaler.scale_
         return (cross_parameter_arrays,cost_arrays,uncertainty_arrays) 
     
     def create_visualizations(self,

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1230,10 +1230,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
                 sample_parameters[:, ind] = cross_parameter_arrays[ind]
                 costs = self.predict_costs_from_param_array(sample_parameters, net_index)
                 cost_arrays.append(costs)
-            if self.cost_scaler.scale_:
-                cross_parameter_arrays = np.array(cross_parameter_arrays)/self.cost_scaler.scale_
-            else:
-                cross_parameter_arrays = np.array(cross_parameter_arrays)
+            cross_parameter_arrays = np.array(cross_parameter_arrays)
             cost_arrays = self.cost_scaler.inverse_transform(np.array(cost_arrays))
             res.append((cross_parameter_arrays, cost_arrays))
         return res

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -846,17 +846,17 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
                 raise ValueError
         
         cross_parameter_arrays = [ np.linspace(min_p, max_p, points) for (min_p,max_p) in zip(self.min_boundary,self.max_boundary)]
-        unscaled_cost_arrays = []
-        unscaled_uncertainty_arrays = []
+        scaled_cost_arrays = []
+        scaled_uncertainty_arrays = []
         for ind in range(self.num_params):
             sample_parameters = np.array([cross_section_center for _ in range(points)])
             sample_parameters[:, ind] = cross_parameter_arrays[ind]
             (costs, uncers) = self.gaussian_process.predict(sample_parameters,return_std=True)
-            unscaled_cost_arrays.append(costs)
-            unscaled_uncertainty_arrays.append(uncers)
+            scaled_cost_arrays.append(costs)
+            scaled_uncertainty_arrays.append(uncers)
         cross_parameter_arrays = np.array(cross_parameter_arrays)
-        cost_arrays = self.cost_scaler.inverse_transform(np.array(unscaled_cost_arrays))
-        uncertainty_arrays = np.array(unscaled_uncertainty_arrays) * self.cost_scaler.scale_
+        cost_arrays = self.cost_scaler.inverse_transform(np.array(scaled_cost_arrays))
+        uncertainty_arrays = np.array(scaled_uncertainty_arrays) * self.cost_scaler.scale_
         return (cross_parameter_arrays,cost_arrays,uncertainty_arrays) 
     
     def create_visualizations(self,

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1224,14 +1224,14 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         res = []
         for net_index in range(self.num_nets):
             cross_parameter_arrays = [ np.linspace(min_p, max_p, points) for (min_p,max_p) in zip(self.min_boundary,self.max_boundary)]
-            cost_arrays = []
+            scaled_cost_arrays = []
             for ind in range(self.num_params):
                 sample_parameters = np.array([cross_section_center for _ in range(points)])
                 sample_parameters[:, ind] = cross_parameter_arrays[ind]
                 costs = self.predict_costs_from_param_array(sample_parameters, net_index)
-                cost_arrays.append(costs)
+                scaled_cost_arrays.append(costs)
             cross_parameter_arrays = np.array(cross_parameter_arrays)
-            cost_arrays = self.cost_scaler.inverse_transform(np.array(cost_arrays))
+            cost_arrays = self.cost_scaler.inverse_transform(np.array(scaled_cost_arrays))
             res.append((cross_parameter_arrays, cost_arrays))
         return res
     


### PR DESCRIPTION
There are a few bugs with scalings, which I've patched in this PR.

The first one is that the uncertainties were scaled the wrong way in `GuassianProcessLearner`. When normalizing costs, the `cost_scaler` divides them by `cost_scaler.scale_` (see [here](https://github.com/scikit-learn/scikit-learn/blob/0fb307bf39bbdacd6ed713c00724f8f871d60370/sklearn/preprocessing/_data.py#L807)) and when rescaling costs back to their original range it multiplies the scaled cost by `cost_scaler.scale_` (see [here](https://github.com/scikit-learn/scikit-learn/blob/0fb307bf39bbdacd6ed713c00724f8f871d60370/sklearn/preprocessing/_data.py#L845)). The same should be done for the uncertainties, but previously the multiplication and division were switched. This PR corrects that issue. Furthermore the uncertainties in `GaussianProcessVisualizer.return_cross_sections()` weren't rescaled back, and this has been corrected as well.

The second issue is more minor. The value of `cross_parameter_arrays` in `GaussianProcessLearner.return_cross_sections()` and `NeuralNetLearner.return_cross_sections()` was scaled previously, but does not need to be scaled. When it is created, its values go between `self.min_boundary` and `self.max_boundary` which aren't scaled, so there's no scaling to undo. This was likely a small mix-up where the scaling was meant to be applied to `uncertainty_arrays` but was accidentally applied to `cross_parameter_arrays` instead, and then that mix-up was copy/pasted to `NeuralNetVisualizer.return_cross_sections()` . Fortunately the value returned for `cross_parameter_arrays` isn't used anywhere in M-LOOP, so it didn't cause any other issues.

Changes proposed in this pull request:

- Correct uncertainty scaling in `GaussianProcessLearner` and `GaussianProcessVisualizer`
- Correct `cross_parameter_arrays` scaling in `GaussianProcessVisualizer` and `NeuralNetVisualizer`

@qctrl/support @charmasaur 
