### PR TITLE
Fix bug where GaussianProcessLearner ignores cost uncertainties.

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1298,7 +1298,7 @@ class GaussianProcessLearner(Learner, mp.Process):
             raise ValueError
         self.scaled_costs = self.cost_scaler.fit_transform(self.all_costs[:,np.newaxis])[:,0]
         self.scaled_uncers = self.all_uncers / self.cost_scaler.scale_
-        self.gaussian_process.alpha_ = self.scaled_uncers
+        self.gaussian_process.set_params(alpha=self.scaled_uncers**2)
         self.gaussian_process.fit(self.all_params,self.scaled_costs)
         
         if self.update_hyperparameters:


### PR DESCRIPTION
The `GaussianProcessLearner` accounts for measured uncertainties on the cost by providing them as the `alpha` property of its `self.gaussian_process`, which is an instance of `GaussianProcessRegressor` ([docs here](https://scikit-learn.org/stable/modules/generated/sklearn.gaussian_process.GaussianProcessRegressor.html#)). Previously it tried to do this by setting `self.gaussian_process.alpha_` (note the trailing underscore) before calling `self.gaussian_process.fit()`. However as can be seen in [the code for `GaussianProcessRegressor.fit()`](https://github.com/scikit-learn/scikit-learn/blob/0fb307bf39bbdacd6ed713c00724f8f871d60370/sklearn/gaussian_process/_gpr.py#L263-L275]), it uses the value of `self.alpha` then overwrites the value of `self.alpha_`, which meant that the cost uncertainties were effectively ignored and the default value for `alpha` was used instead. This PR remedies that by setting the value for `alpha` instead of `alpha_`.

As mentioned in the docs linked above, `alpha` is added to the diagonal of the kernel's covariance matrix. That means it should be a variance rather than a standard deviation. To be extra certain of this, note that those docs state that setting `alpha` to a constant value is the same as adding a `WhiteKernel` with its `noise_level` set to `alpha`. As mentioned in the [docs for `WhiteKernel`](https://scikit-learn.org/stable/modules/generated/sklearn.gaussian_process.kernels.WhiteKernel.html#) the `noise_level` is a variance, which further confirms that `alpha` should then be a variance as well. With this in mind the measured uncertainties are now squared before passing them as `alpha` . This probably won't change the behavior much, but might as well fix it anyway.

Changes proposed in this pull request:

- Fix bug where cost uncertainties are ignored by `GaussianProcessLearner` by setting `self.gaussian_process.alpha` instead of `self.gaussian_process.alpha_`.
- Square uncertainties to variances before passing them as `self.gaussian_process.alpha`

@qctrl/support @charmasaur 
