### PR TITLE
Record M-LOOP version number in log and archives.

### DIFF
--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import datetime
+from mloop import __version__
 import mloop.utilities as mlu
 import mloop.learners as mll
 import mloop.interfaces as mli
@@ -195,7 +196,8 @@ class Controller():
             if not os.path.exists(archive_dir):
                 os.makedirs(archive_dir)
 
-        self.archive_dict = {'archive_type':'controller',
+        self.archive_dict = {'mloop_version':__version__,
+                             'archive_type':'controller',
                              'num_out_params':self.num_out_params,
                              'out_params':self.out_params,
                              'out_type':self.out_type,

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -21,6 +21,7 @@ import sklearn.gaussian_process as skg
 import sklearn.gaussian_process.kernels as skk
 import sklearn.preprocessing as skp
 
+from mloop import __version__
 import mloop.neuralnet as mlnn
 #Lazy import of scikit-learn and tensorflow
 
@@ -157,7 +158,8 @@ class Learner():
         # Ensure that all of the entries are strings.
         self.param_names = [str(name) for name in self.param_names]
         
-        self.archive_dict = {'archive_type':'learner',
+        self.archive_dict = {'mloop_version':__version__,
+                             'archive_type':'learner',
                              'num_params':self.num_params,
                              'min_boundary':self.min_boundary,
                              'max_boundary':self.max_boundary,

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -83,6 +83,7 @@ def _config_logger(log_filename = default_log_filename,
         ch.setLevel(console_log_level)
         ch.setFormatter(logging.Formatter('%(levelname)-8s %(message)s'))
         log.addHandler(ch)
+        log.info('MLOOP version ' + mloop.__version__)
         log.debug('MLOOP Logger configured.')
     
     return kwargs


### PR DESCRIPTION
Saving the M-LOOP version number in the log and in the controller and learner archives seems like generally a good thing to do. For example, it allows users to figure out whether or not their optimization ran with a version of M-LOOP that had a particular bug fix.

This also makes it easier to maintain backwards compatibility. For example, after PR #74 the meaning of `noise_level` has changed slightly, so it may make sense to interpret archives from previous versions of M-LOOP slightly differently than archives from more recent versions. In fact that's what led me to issue this PR, and I'll submit another PR soon to actually implement the proper interpretation of `noise_level` from old archives.

Changes proposed in this pull request:

- Record the version number of M-LOOP in the log and archives it generates.

@qctrl/support
