### PR TITLE
Minimum uncertainty bugs

### DIFF
--- a/examples/gaussian_process_complete_config.txt
+++ b/examples/gaussian_process_complete_config.txt
@@ -13,6 +13,7 @@ max_boundary = [10., 10.]              #maximum boundary
 param_names = ['a', 'b']               #names for parameters
 length_scale = [1.0]                   #initial lengths scales for GP
 length_scale_bounds = [-1e5, 1e5]      #limits on values fit for length_scale
+minimum_uncertainty = 1e-8             #minimum uncertainty of cost, required to avoid fitting errors
 cost_has_noise = True                  #whether cost function has noise
 noise_level = 0.1                      #initial noise level estimate, cost's variance (standard deviation squared)
 noise_level_bounds = [1e-5, 1e5]       #limits on values fit for noise_level

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1314,9 +1314,10 @@ class GaussianProcessLearner(Learner, mp.Process):
             if not self.check_in_boundary(param):
                 self.log.warning('Parameters provided to Gaussian process learner not in boundaries:' + repr(param))
             cost = float(cost)
+            uncer = float(uncer)
             if uncer < 0:
                 self.log.error('Provided uncertainty must be larger or equal to zero:' + repr(uncer))
-                uncer = max(float(uncer), self.minimum_uncertainty)
+            uncer = max(uncer, self.minimum_uncertainty)
             
             cost_change_flag = False
             if cost > self.worst_cost:
@@ -1925,9 +1926,10 @@ class NeuralNetLearner(Learner, mp.Process):
             if not self.check_in_boundary(param):
                 self.log.warning('Parameters provided to neural network learner not in boundaries:' + repr(param))
             cost = float(cost)
+            uncer = float(uncer)
             if uncer < 0:
                 self.log.error('Provided uncertainty must be larger or equal to zero:' + repr(uncer))
-                uncer = max(float(uncer), self.minimum_uncertainty)
+            uncer = max(uncer, self.minimum_uncertainty)
 
             cost_change_flag = False
             if cost > self.worst_cost:


### PR DESCRIPTION
Previously the value of `self.minimum_uncertainty` for `GaussianProcessLearner` and `NeuralNetLearner` wasn't always applied. It worked when the provided uncertainty `uncer` was less than zero, but it wasn't applied when `uncer > 0` but `uncer < self.minimum_uncertainty`. This PR fixes that.

Also, the `minimum_uncertainty` option was mentioned in the complete  example config for the neural net learner, but not for the Gaussian process learner, so that has been updated as well.

Changes proposed in this pull request:

- Always apply `self.minimum_uncertainty`, even if `uncer > 0`, for `GaussianProcessLearner` and `NeuralNetLearner`
- Mention `minimum_uncertainty` in `gaussian_process_complete_config.txt`.
