### PR TITLE
Removed trailing whitespace in several files

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,7 +8,7 @@ M-LOOP includes a series of example configuration files for each of the controll
 
 The options available are also comprehensively documented in the :ref:`sec-api` as keywords for each of the classes. However, the quickest and easiest way to learn what options are available, if you are not familiar with python, is to just look at the provided examples.
 
-Each of the example files is used when running tests of M-LOOP. So please copy and modify them elsewhere if you use them as a starting point for your configuration file. 
+Each of the example files is used when running tests of M-LOOP. So please copy and modify them elsewhere if you use them as a starting point for your configuration file.
 
 Interfaces
 ==========
@@ -35,7 +35,7 @@ The shell interface is for experiments that can be run through a command execute
 .. include:: ../examples/shell_interface_config.txt
    :literal:
 
-   
+
 Controllers
 ===========
 
@@ -49,19 +49,19 @@ Each of the controllers and their specific options are described below. There is
 
 .. include:: ../examples/controller_config.txt
    :literal:
-   
+
 Gaussian process
 ----------------
 
 The Gaussian process controller is the default controller.
 It uses a `Gaussian process <http://scikit-learn.org/dev/modules/gaussian_process.html>`_ to develop a model for how the parameters relate to the measured cost, effectively creating a model for how the experiment operates.
-This model is then used when picking new points to test. 
+This model is then used when picking new points to test.
 
 There are two example files for the Gaussian-process controller: *gaussian_process_simple_config.txt* which contains the basic options.
 
 .. include:: ../examples/gaussian_process_simple_config.txt
    :literal:
-   
+
 *gaussian_process_complete_config.txt* which contains a comprehensive list of options.
 
 .. include:: ../examples/gaussian_process_complete_config.txt
@@ -71,7 +71,7 @@ Note that ``noise_level`` corresponds to a variance, not a standard deviation.
 In particular ``noise_level`` estimates the variance if the cost for a given set of parameters were measured many times.
 This is in contrast to the cost uncertainty that the user optionally passes to M-LOOP with the cost itself; that should be the standard deviation.
 In other words the cost uncertainty should estimate the standard deviation if the cost for a given set of parameters were measured many times.
-   
+
 Neural net
 ----------------
 
@@ -88,7 +88,7 @@ There are two example files for the neural net controller: *neural_net_simple_co
 
 .. include:: ../examples/neural_net_simple_config.txt
    :literal:
-   
+
 *neural_net_complete_config.txt* which contains a comprehensive list of options.
 
 .. include:: ../examples/neural_net_complete_config.txt
@@ -97,19 +97,19 @@ There are two example files for the neural net controller: *neural_net_simple_co
 Differential evolution
 ----------------------
 
-The differential evolution (DE) controller uses a `DE algorithm <https://en.wikipedia.org/wiki/Differential_evolution>`_ for optimization. DE is a type of evolutionary algorithm, and is historically the most commonly used in automated optimization. DE will eventually find a global solution, however it can take many experiments before it does so. 
+The differential evolution (DE) controller uses a `DE algorithm <https://en.wikipedia.org/wiki/Differential_evolution>`_ for optimization. DE is a type of evolutionary algorithm, and is historically the most commonly used in automated optimization. DE will eventually find a global solution, however it can take many experiments before it does so.
 
 There are two example files for the differential evolution controller: *differential_evolution_simple_config.txt* which contains the basic options.
 
 .. include:: ../examples/differential_evolution_simple_config.txt
    :literal:
-   
+
 *differential_evolution_complete_config.txt* which contains a comprehensive list of options.
 
 .. include:: ../examples/differential_evolution_complete_config.txt
    :literal:
-   
-   
+
+
 Nelder–Mead
 -----------
 
@@ -119,27 +119,27 @@ There are two example files for the Nelder–Mead controller: *nelder_mead_simpl
 
 .. include:: ../examples/nelder_mead_simple_config.txt
    :literal:
-   
+
 *nelder_mead_complete_config.txt* which contains a comprehensive list of options.
 
 .. include:: ../examples/nelder_mead_complete_config.txt
    :literal:
-   
+
 Random
 ------
 
-The random optimization algorithm picks parameters randomly from a uniform distribution from within the parameter bounds or trust region. 
+The random optimization algorithm picks parameters randomly from a uniform distribution from within the parameter bounds or trust region.
 
 There are two example files for the random controller: *random_simple_config.txt* which contains the basic options.
 
 .. include:: ../examples/random_simple_config.txt
    :literal:
-   
+
 *random_complete_config.txt* which contains a comprehensive list of options.
 
 .. include:: ../examples/random_complete_config.txt
    :literal:
-   
+
 Logging
 =======
 

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -164,7 +164,7 @@ class Learner():
                              'start_datetime':mlu.datetime_to_string(self.start_datetime),
                              'param_names':self.param_names}
 
-        self.log.debug('Learner init completed.')   
+        self.log.debug('Learner init completed.')
 
     def _prepare_logger(self):
         '''
@@ -901,7 +901,7 @@ class DifferentialEvolutionLearner(Learner, threading.Thread):
 class MachineLearner(Learner):
     '''
     A parent class for more specific machine learer classes.
-    
+
     This class is not intended to be used directly.
 
     Keyword Args:
@@ -912,7 +912,7 @@ class MachineLearner(Learner):
             distance the learner will venture as a percentage of the boundaries.
             If it is an array, it must have the same size as the number of
             parameters and the numbers define the maximum absolute distance that
-            can be moved along each direction. 
+            can be moved along each direction.
         default_bad_cost (Optional [float]): If a run is reported as bad and
             `default_bad_cost` is provided, the cost for the bad run is set to
             this default value. If `default_bad_cost` is `None`, then the worst
@@ -931,28 +931,28 @@ class MachineLearner(Learner):
         training_filename (Optional [str]): The name of a learner archive from a
             previous optimization from which to extract past results for use in
             the current optimization. If `None`, no past results will be used.
-            Default `None`. 
+            Default `None`.
         training_file_type (Optional [str]): File type of the training archive.
             Can be `'txt'`, `'pkl'`, `'mat'`, or `None`. If set to `None`, then
             the file type will be determined automatically. This argument has no
-            effect if `training_filename` is set to `None`. Default `None`. 
+            effect if `training_filename` is set to `None`. Default `None`.
 
     Attributes:
         all_params (array): Array containing all parameters sent to learner.
         all_costs (array): Array containing all costs sent to learner.
         all_uncers (array): Array containing all uncertainties sent to learner.
-        scaled_costs (array): Array contaning all the costs scaled to have zero mean and a standard deviation of 1. Needed for training the learner. 
+        scaled_costs (array): Array contaning all the costs scaled to have zero mean and a standard deviation of 1. Needed for training the learner.
         bad_run_indexs (list): list of indexes to all runs that were marked as bad.
         best_cost (float): Minimum received cost, updated during execution.
         best_params (array): Parameters of best run. (reference to element in params array).
-        best_index (int): index of the best cost and params. 
+        best_index (int): index of the best cost and params.
         worst_cost (float): Maximum received cost, updated during execution.
         worst_index (int): index to run with worst cost.
         cost_range (float): Difference between worst_cost and best_cost
-        params_count (int): Counter for the number of parameters asked to be evaluated by the learner.  
-        has_trust_region (bool): Whether the learner has a trust region. 
+        params_count (int): Counter for the number of parameters asked to be evaluated by the learner.
+        has_trust_region (bool): Whether the learner has a trust region.
     '''
-    
+
     def __init__(self,
                  trust_region=None,
                  default_bad_cost = None,
@@ -1026,7 +1026,7 @@ class MachineLearner(Learner):
             self.all_params = np.array(self.training_dict['all_params'], dtype=float)
             self.all_costs = mlu.safe_cast_to_array(self.training_dict['all_costs'])
             self.all_uncers = mlu.safe_cast_to_array(self.training_dict['all_uncers'])
-            self.bad_run_indexs = mlu.safe_cast_to_list(self.training_dict['bad_run_indexs'])            
+            self.bad_run_indexs = mlu.safe_cast_to_list(self.training_dict['bad_run_indexs'])
 
             #Derived properties
             self.best_cost = float(self.training_dict['best_cost'])
@@ -1071,7 +1071,7 @@ class MachineLearner(Learner):
         # Constants, limits and tolerances
         self.search_precision = 1.0e-6
         self.parameter_searches = max(10, self.num_params)
-        self.bad_uncer_frac = 0.1 # Fraction of cost range to set a bad run uncertainty 
+        self.bad_uncer_frac = 0.1 # Fraction of cost range to set a bad run uncertainty
 
         # Optional user set variables
         self._set_trust_region(trust_region)
@@ -1175,7 +1175,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         cost_has_noise (Optional [bool]): If true the learner assumes there is common additive white noise that corrupts the costs provided. This noise is assumed to be on top of the uncertainty in the costs (if it is provided). If false, it is assumed that there is no noise in the cost (or if uncertainties are provided no extra noise beyond the uncertainty). Default True.
         noise_level (Optional [float]): The initial guess for the noise level (variance, not standard deviation) in the costs, is only used if cost_has_noise is true. If None, it will be set to the variance of the training data costs. Default None.
         noise_level_bounds (Optional [array]): The limits on the fitted noise_level values, specified as a single pair of numbers [min, max]. This only has an effect if update_hyperparameters and cost_has_noise are both set to True. If set to None, the value [1e-5 * var, 1e5 * var] will be used where var is the variance of the training data costs. Default None.
-        gp_training_filename (Optional [str]): The name of a learner archive from a previous optimization from which to extract past results for use in the current optimization. If `None`, no past results will be used. Default `None`. 
+        gp_training_filename (Optional [str]): The name of a learner archive from a previous optimization from which to extract past results for use in the current optimization. If `None`, no past results will be used. Default `None`.
         gp_training_file_type (Optional [str]): File type of the training
             archive. Can be `'txt'`, `'pkl'`, `'mat'`, or `None`. If set to
             `None`, then the file type will be determined automatically. This
@@ -1254,7 +1254,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
                     length_scale_bounds = mlu.safe_cast_to_array(self.training_dict['length_scale_bounds'])
                 if 'noise_level_bounds' in self.training_dict:
                     noise_level_bounds = mlu.safe_cast_to_array(self.training_dict['noise_level_bounds'])
-            
+
             #Storage variables, archived
             self.length_scale_history = list(self.training_dict['length_scale_history'])
             self.noise_level_history = mlu.safe_cast_to_list(self.training_dict['noise_level_history'])
@@ -1808,12 +1808,12 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         nn_training_filename (Optional [str]): The name of a learner archive
             from a previous optimization from which to extract past results for
             use in the current optimization. If `None`, no past results will be
-            used. Default `None`. 
+            used. Default `None`.
         nn_training_file_type (Optional [str]): File type of the training
             archive. Can be `'txt'`, `'pkl'`, `'mat'`, or `None`. If set to
             `None`, then the file type will be determined automatically. This
             argument has no effect if `nn_training_filename` is set to `None`.
-            Default `None`. 
+            Default `None`.
         trust_region (Optional [float or array]): The trust region defines the maximum distance the learner will travel from the current best set of parameters. If None, the learner will search everywhere. If a float, this number must be between 0 and 1 and defines maximum distance the learner will venture as a percentage of the boundaries. If it is an array, it must have the same size as the number of parameters and the numbers define the maximum absolute distance that can be moved along each direction.
         default_bad_cost (Optional [float]): If a run is reported as bad and default_bad_cost is provided, the cost for the bad run is set to this default value. If default_bad_cost is None, then the worst cost received is set to all the bad runs. Default None.
         default_bad_uncertainty (Optional [float]): If a run is reported as bad and default_bad_uncertainty is provided, the uncertainty for the bad run is set to this default value. If default_bad_uncertainty is None, then the uncertainty is set to a tenth of the best to worst cost range. Default None.
@@ -1867,7 +1867,7 @@ class NeuralNetLearner(MachineLearner, mp.Process):
             # The scaler will be initialised when we're ready to fit it
             self.cost_scaler = None
             self.cost_scaler_init_index = None
- 
+
         #Constants, limits and tolerances
         self.num_nets = 3
         self.generation_num = 3

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -173,7 +173,7 @@ class SingleNeuralNet():
     def load(self, archive, extra_search_dirs=None):
         '''
         Imports the net from an archive dictionary. You must call exactly one of this and init() before calling any other methods.
-        
+
         Args:
             archive (dict): An archive dictionary containing the data from a
                 neural net learner archive, typically created using
@@ -188,7 +188,7 @@ class SingleNeuralNet():
         # Set default value of extra_search_dirs if necessary.
         if extra_search_dirs is None:
             extra_search_dirs = []
-        
+
         # Get the saved filename and construct a list of directories to in which
         # to look for it.
         self.log.info("Loading neural network")
@@ -196,7 +196,7 @@ class SingleNeuralNet():
         saved_dirname, filename = os.path.split(saver_path)
         saved_dirname = os.path.join('.', saved_dirname)
         search_dirs = [saved_dirname] + extra_search_dirs
-        
+
         # Check each directory for the file.
         for dirname in search_dirs:
             try:
@@ -205,7 +205,7 @@ class SingleNeuralNet():
                 return
             except ValueError:
                 pass
-        
+
         # If the method hasn't returned by now then it's run out of places to
         # look.
         message = "Could not find neural net archive {filename}.".format(filename=filename)
@@ -566,7 +566,7 @@ class NeuralNet():
 
         You must only load a net from an archive if that archive corresponds to a net with the same
         constructor parameters.
-        
+
         Args:
             archive (dict): An archive dictionary containing the data from a
                 neural net learner archive, typically created using

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -29,12 +29,12 @@ legend_loc = _DEFAULT_LEGEND_LOC
 def set_legend_location(loc=None):
     '''
     Set the location of the legend in future figures.
-    
+
     Note that this function doesn't change the location of legends in existing
     figures. It only changes where legends will appear in figures generated
     after the call to this function. If called without arguments, the legend
     location for future figures will revert to its default value.
-    
+
     Keyword Args:
         loc (Optional str, int, or pair of floats): The value to use for loc in
             the calls to matplotlib's legend(). Can be e.g. 2, 'upper right',
@@ -45,7 +45,7 @@ def set_legend_location(loc=None):
     # Set default value for loc if necessary.
     if loc is None:
         loc = _DEFAULT_LEGEND_LOC
-    
+
     # Update the global used for setting the legend location.
     global legend_loc
     legend_loc = loc
@@ -55,10 +55,10 @@ def show_all_default_visualizations(controller,
                                     max_parameters_per_plot=None):
     '''
     Plots all visualizations available for a controller, and it's internal learners.
-    
+
     Args:
         controller (Controller): The controller to extract plots from
-        
+
     Keyword Args:
         show_plots (Optional, bool): Determine whether to run plt.show() at the
             end or not. For debugging. Default True.
@@ -77,7 +77,7 @@ def show_all_default_visualizations(controller,
         controller.total_archive_filename,
         max_parameters_per_plot=max_parameters_per_plot,
     )
-    
+
     # For machine learning controllers, the controller.learner is actually the
     # learner for the trainer while controller.ml_learner is the machine
     # learning controller. For other controllers, controller.learner is the
@@ -86,13 +86,13 @@ def show_all_default_visualizations(controller,
         learner_archive_filename = controller.ml_learner.total_archive_filename
     except AttributeError:
         learner_archive_filename = controller.learner.total_archive_filename
-    
+
     log.debug('Creating learner visualizations.')
     create_learner_visualizations(
         learner_archive_filename,
         max_parameters_per_plot=max_parameters_per_plot,
     )
-        
+
     log.info('Showing visualizations, close all to end M-LOOP.')
     if show_plots:
         plt.show()
@@ -107,13 +107,13 @@ def show_all_default_visualizations_from_archive(controller_filename,
                                                  learner_visualizer_init_kwargs=None):
     '''
     Plots all visualizations available for a controller and its learner from their archives.
-    
+
     Args:
         controller_filename (str): The filename, including path, of the
             controller archive.
         learner_filename (str): The filename, including path, of the learner
             archive.
-        
+
     Keyword Args:
         controller_type (str): The value of controller_type type used in the
             optimization corresponding to the learner learner archive, e.g.
@@ -121,7 +121,7 @@ def show_all_default_visualizations_from_archive(controller_filename,
             set to None then controller_type will be determined automatically.
             Default None.
         show_plots (bool): Determine whether to run plt.show() at the end or
-            not. For debugging. Default True. 
+            not. For debugging. Default True.
         max_parameters_per_plot (Optional [int]): The maximum number of
             parameters to include in plots that display the values of
             parameters. If the number of parameters is larger than
@@ -145,22 +145,22 @@ def show_all_default_visualizations_from_archive(controller_filename,
     # Set default value for controller_visualization_kwargs if necessary.
     if controller_visualization_kwargs is None:
         controller_visualization_kwargs = {}
-    
+
     # Update controller_visualization_kwargs with max_parameters_per_plot if
     # necessary.
     if 'max_parameters_per_plot' not in controller_visualization_kwargs:
         controller_visualization_kwargs['max_parameters_per_plot'] = max_parameters_per_plot
-    
+
     log = logging.getLogger(__name__)
     configure_plots()
-    
+
     # Create visualizations for the controller archive.
     log.debug('Creating controller visualizations.')
     create_controller_visualizations(
         controller_filename,
         **controller_visualization_kwargs,
     )
-    
+
     # Create visualizations for the learner archive.
     create_learner_visualizations(
         learner_filename,
@@ -176,10 +176,10 @@ def show_all_default_visualizations_from_archive(controller_filename,
 def create_learner_visualizer_from_archive(filename, controller_type=None, **kwargs):
     '''
     Create an instance of the appropriate visualizer class for a learner archive.
-    
+
     Args:
         filename (String): Filename of the learner archive.
-    
+
     Keyword Args:
         controller_type (String): The type of controller used during the
             optimization that created the provided learner archive. Options
@@ -196,7 +196,7 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
     # Automatically determine controller_type if necessary.
     if controller_type is None:
         controller_type = mlu.get_controller_type_from_learner_archive(filename)
-        
+
     # Create an instance of the appropriate visualizer class for the archive.
     log = logging.getLogger(__name__)
     if controller_type == 'neural_net':
@@ -213,7 +213,7 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
                    'for type: {type_}.').format(type_=controller_type)
         log.error(message)
         raise ValueError(message)
-    
+
     return visualizer
 
 def create_learner_visualizations(filename,
@@ -222,10 +222,10 @@ def create_learner_visualizations(filename,
                                   learner_visualizer_init_kwargs=None):
     '''
     Runs the plots for a learner archive file.
-    
+
     Args:
-        filename (str): Filename for the learner archive. 
-    
+        filename (str): Filename for the learner archive.
+
     Keyword Args:
         max_parameters_per_plot (Optional [int]): The maximum number of
             parameters to include in plots that display the values of
@@ -248,12 +248,12 @@ def create_learner_visualizations(filename,
         learner_visualization_kwargs = {}
     if learner_visualizer_init_kwargs is None:
         learner_visualizer_init_kwargs = {}
-        
+
     # Update controller_visualization_kwargs with max_parameters_per_plot if
     # necessary.
     if 'max_parameters_per_plot' not in learner_visualization_kwargs:
         learner_visualization_kwargs['max_parameters_per_plot'] = max_parameters_per_plot
-    
+
     # Create a visualizer and have it make the plots.
     visualizer = create_learner_visualizer_from_archive(
         filename,
@@ -270,7 +270,7 @@ def _color_from_controller_name(controller_name):
 
 def _color_list_from_num_of_params(num_of_params):
     '''
-    Gives a list of colors based on the number of parameters. 
+    Gives a list of colors based on the number of parameters.
     '''
     global cmap
     return [cmap(float(x)/num_of_params) for x in range(num_of_params)]
@@ -278,7 +278,7 @@ def _color_list_from_num_of_params(num_of_params):
 def _ensure_parameter_subset_valid(visualizer, parameter_subset):
     '''
     Make sure indices in parameter_subset are acceptable.
-    
+
     Args:
         visualizer (ControllerVisualizer-like): An instance of one of the
             visualization classes defined in this module, which should have the
@@ -307,16 +307,16 @@ def configure_plots():
     mpl.rcParams['legend.numpoints'] = 1
     mpl.rcParams['legend.scatterpoints'] = 1
     mpl.rcParams['legend.fontsize']= 'medium'
-    
+
 def create_controller_visualizations(filename,
                                     file_type=None,
                                     **kwargs):
     '''
     Runs the plots for a controller file.
-    
+
     Args:
         filename (String): Filename of the controller archive.
-    
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
@@ -329,23 +329,23 @@ def create_controller_visualizations(filename,
 
 class ControllerVisualizer():
     '''
-    ControllerVisualizer creates figures from a Controller Archive. 
-    
+    ControllerVisualizer creates figures from a Controller Archive.
+
     Args:
         filename (String): Filename of the controller archive.
-    
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
-    
+
     '''
     def __init__(self, filename,
                  file_type=None,
                  **kwargs):
-        
+
         self.log = logging.getLogger(__name__)
-        
+
         self.filename = str(filename)
         # Automatically determine file_type if necessary.
         if file_type is None:
@@ -354,12 +354,12 @@ class ControllerVisualizer():
         if not mlu.check_file_type_supported(self.file_type):
             self.log.error('File type not supported: ' + repr(self.file_type))
         controller_dict = mlu.get_dict_from_file(self.filename, self.file_type)
-            
+
         self.archive_type = controller_dict['archive_type']
         if 'archive_type' in controller_dict and not (controller_dict['archive_type'] == 'controller'):
             self.log.error('The archive appears to be the wrong type.')
             raise ValueError
-        
+
         self.num_in_costs = int(controller_dict['num_in_costs'])
         self.num_out_params = int(controller_dict['num_out_params'])
         self.out_params = np.array(controller_dict['out_params'])
@@ -372,20 +372,20 @@ class ControllerVisualizer():
         self.min_boundary = np.squeeze(np.array(controller_dict['min_boundary']))
         self.max_boundary = np.squeeze(np.array(controller_dict['max_boundary']))
         self.param_names = mlu._param_names_from_file_dict(controller_dict)
-        
+
         if np.all(np.isfinite(self.min_boundary)) and np.all(np.isfinite(self.max_boundary)):
             self.finite_flag = True
             self.param_scaler = lambda p: (p-self.min_boundary)/(self.max_boundary - self.min_boundary)
             self.scaled_params = np.array([self.param_scaler(self.out_params[ind,:]) for ind in range(self.num_out_params)])
         else:
             self.finite_flag = False
-        
+
         self.unique_types = set(self.out_type)
         self.cost_colors = [_color_from_controller_name(x) for x in self.out_type]
         self.in_numbers = np.arange(1,self.num_in_costs+1)
         self.out_numbers = np.arange(1,self.num_out_params+1)
         self.param_numbers = np.arange(self.num_params)
-    
+
     def create_visualizations(self,
                               plot_cost_vs_run=True,
                               plot_parameters_vs_run=True,
@@ -393,14 +393,14 @@ class ControllerVisualizer():
                               max_parameters_per_plot=None):
         '''
         Runs the plots for a controller file.
-        
+
         Keyword Args:
             plot_cost_vs_run (Optional [bool]): If True plot cost versus run
-                number, else do not. Default True. 
+                number, else do not. Default True.
             plot_parameters_vs_run (Optional [bool]): If True plot parameters
-                versus run number, else do not. Default True. 
+                versus run number, else do not. Default True.
             plot_parameters_vs_cost (Optional [bool]): If True plot parameters
-                versus cost number, else do not. Default True. 
+                versus cost number, else do not. Default True.
             max_parameters_per_plot (Optional [int]): The maximum number of
                 parameters to include in plots that display the values of
                 parameters. If the number of parameters is larger than
@@ -413,18 +413,18 @@ class ControllerVisualizer():
             self.param_numbers,
             max_parameters_per_plot,
         )
-        
+
         if plot_cost_vs_run:
             self.plot_cost_vs_run()
-            
+
         if plot_parameters_vs_run:
             for parameter_chunk in parameter_chunks:
                 self.plot_parameters_vs_run(parameter_subset=parameter_chunk)
-                
+
         if plot_parameters_vs_cost:
             for parameter_chunk in parameter_chunks:
                 self.plot_parameters_vs_cost(parameter_subset=parameter_chunk)
-        
+
     def plot_cost_vs_run(self):
         '''
         Create a plot of the costs versus run number.
@@ -432,7 +432,7 @@ class ControllerVisualizer():
         global figure_counter, run_label, cost_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
-        
+
         # Only plot points for which a cost was actually measured. This may not
         # be the case for all parameter sets if the optimization is still in
         # progress, or ended by a keyboard interupt, etc..
@@ -440,7 +440,7 @@ class ControllerVisualizer():
         in_costs = self.in_costs[:self.num_in_costs]
         in_uncers = self.in_uncers[:self.num_in_costs]
         cost_colors = self.cost_colors[:self.num_in_costs]
-        
+
         plt.scatter(in_numbers, in_costs+in_uncers, marker='_', color='k')
         plt.scatter(in_numbers, in_costs-in_uncers, marker='_', color='k')
         plt.scatter(in_numbers, in_costs,marker='o', c=cost_colors, s=5*mpl.rcParams['lines.markersize'])
@@ -451,14 +451,14 @@ class ControllerVisualizer():
         for ut in self.unique_types:
             artists.append(plt.Line2D((0,1),(0,0), color=_color_from_controller_name(ut), marker='o', linestyle=''))
         plt.legend(artists,self.unique_types,loc=legend_loc)
-    
+
     def _ensure_parameter_subset_valid(self, parameter_subset):
         _ensure_parameter_subset_valid(self, parameter_subset)
-        
+
     def plot_parameters_vs_run(self, parameter_subset=None):
         '''
         Create a plot of the parameters versus run number.
-    
+
         Args:
             parameter_subset (list-like): The indices of parameters to plot. The
                 indices should be 0-based, i.e. the first parameter is
@@ -470,14 +470,14 @@ class ControllerVisualizer():
         # Get default value for parameter_subset if necessary.
         if parameter_subset is None:
             parameter_subset = self.param_numbers
-        
+
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
-        
+
         # Generate set of distinct colors for plotting.
         num_params = len(parameter_subset)
         param_colors = _color_list_from_num_of_params(num_params)
-            
+
         global figure_counter, run_label, scale_param_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
@@ -495,7 +495,7 @@ class ControllerVisualizer():
                 plt.plot(self.out_numbers,self.out_params[:,param_index],'o',color=color)
                 plt.ylabel(run_label)
         plt.xlabel(run_label)
-        
+
         plt.title('Controller: Parameters vs run number.')
         artists=[]
         for ind in range(num_params):
@@ -506,11 +506,11 @@ class ControllerVisualizer():
             self.param_names,
         )
         plt.legend(artists, legend_labels ,loc=legend_loc)
-        
+
     def plot_parameters_vs_cost(self, parameter_subset=None):
         '''
         Create a plot of the parameters versus run number.
-    
+
         Args:
             parameter_subset (list-like): The indices of parameters to plot. The
                 indices should be 0-based, i.e. the first parameter is
@@ -524,22 +524,22 @@ class ControllerVisualizer():
         # progress, or ended by a keyboard interupt, etc..
         in_costs = self.in_costs[:self.num_in_costs]
         in_uncers = self.in_uncers[:self.num_in_costs]
-        
+
         # Get default value for parameter_subset if necessary.
         if parameter_subset is None:
             parameter_subset = self.param_numbers
-        
+
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
-        
+
         # Generate set of distinct colors for plotting.
         num_params = len(parameter_subset)
         param_colors = _color_list_from_num_of_params(num_params)
-        
+
         global figure_counter, run_label, run_label, scale_param_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
-        
+
         if self.finite_flag:
             scaled_params = self.scaled_params[:self.num_in_costs,:]
             for ind in range(num_params):
@@ -576,11 +576,11 @@ def create_differential_evolution_learner_visualizations(filename,
                                                          **kwargs):
     '''
     Runs the plots from a differential evolution learner file.
-    
+
     Args:
         filename (String): Filename for the differential evolution learner
             archive.
-        
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
@@ -593,23 +593,23 @@ def create_differential_evolution_learner_visualizations(filename,
 
 class DifferentialEvolutionVisualizer():
     '''
-    DifferentialEvolutionVisualizer creates figures from a differential evolution archive. 
-    
+    DifferentialEvolutionVisualizer creates figures from a differential evolution archive.
+
     Args:
         filename (String): Filename of the DifferentialEvolutionVisualizer archive.
-    
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
-    
+
     '''
     def __init__(self, filename,
                  file_type=None,
                  **kwargs):
-        
+
         self.log = logging.getLogger(__name__)
-        
+
         self.filename = str(filename)
         # Automatically determine file_type if necessary.
         if file_type is None:
@@ -618,12 +618,12 @@ class DifferentialEvolutionVisualizer():
         if not mlu.check_file_type_supported(self.file_type):
             self.log.error('File type not supported: ' + repr(self.file_type))
         learner_dict = mlu.get_dict_from_file(self.filename, self.file_type)
-        
+
         if 'archive_type' in learner_dict and not (learner_dict['archive_type'] == 'differential_evolution'):
             self.log.error('The archive appears to be the wrong type.' + repr(learner_dict['archive_type']))
             raise ValueError
         self.archive_type = learner_dict['archive_type']
-        
+
         self.num_generations = int(learner_dict['generation_count'])
         self.num_population_members = int(learner_dict['num_population_members'])
         self.num_params = int(learner_dict['num_params'])
@@ -632,28 +632,28 @@ class DifferentialEvolutionVisualizer():
         self.param_names = mlu._param_names_from_file_dict(learner_dict)
         self.params_generations = np.array(learner_dict['params_generations'])
         self.costs_generations = np.array(learner_dict['costs_generations'])
-          
+
         self.finite_flag = True
         self.param_scaler = lambda p: (p-self.min_boundary)/(self.max_boundary - self.min_boundary)
         self.scaled_params_generations = np.array([[self.param_scaler(self.params_generations[inda,indb,:]) for indb in range(self.num_population_members)] for inda in range(self.num_generations)])
         self.param_numbers = np.arange(self.num_params)
-        
+
         self.gen_numbers = np.arange(1,self.num_generations+1)
         self.param_colors = _color_list_from_num_of_params(self.num_params)
         self.gen_plot = np.array([np.full(self.num_population_members, ind, dtype=int) for ind in self.gen_numbers]).flatten()
-        
+
     def create_visualizations(self,
                               plot_params_vs_generations=True,
                               plot_costs_vs_generations=True,
                               max_parameters_per_plot=None):
         '''
         Runs the plots from a differential evolution learner file.
-            
+
         Keyword Args:
             plot_params_generations (Optional [bool]): If True plot parameters
-                vs generations, else do not. Default True. 
+                vs generations, else do not. Default True.
             plot_costs_generations (Optional [bool]): If True plot costs vs
-                generations, else do not. Default True. 
+                generations, else do not. Default True.
             max_parameters_per_plot (Optional [int]): The maximum number of
                 parameters to include in plots that display the values of
                 parameters. If the number of parameters is larger than
@@ -666,16 +666,16 @@ class DifferentialEvolutionVisualizer():
             self.param_numbers,
             max_parameters_per_plot,
         )
-        
+
         if plot_params_vs_generations:
             for parameter_chunk in parameter_chunks:
                 self.plot_params_vs_generations(
                     parameter_subset=parameter_chunk,
                 )
-                
+
         if plot_costs_vs_generations:
             self.plot_costs_vs_generations()
-        
+
     def plot_costs_vs_generations(self):
         '''
         Create a plot of the costs versus run number.
@@ -683,7 +683,7 @@ class DifferentialEvolutionVisualizer():
         if self.costs_generations.size == 0:
             self.log.warning('Unable to plot DE: costs vs generations as the initial generation did not complete.')
             return
-        
+
         global figure_counter, cost_label, generation_label
         figure_counter += 1
         plt.figure(figure_counter)
@@ -691,14 +691,14 @@ class DifferentialEvolutionVisualizer():
         plt.xlabel(generation_label)
         plt.ylabel(cost_label)
         plt.title('Differential evolution: Cost vs generation number.')
-    
+
     def _ensure_parameter_subset_valid(self, parameter_subset):
         _ensure_parameter_subset_valid(self, parameter_subset)
-        
+
     def plot_params_vs_generations(self, parameter_subset=None):
         '''
         Create a plot of the parameters versus run number.
-    
+
         Args:
             parameter_subset (list-like): The indices of parameters to plot. The
                 indices should be 0-based, i.e. the first parameter is
@@ -710,22 +710,22 @@ class DifferentialEvolutionVisualizer():
         # Get default value for parameter_subset if necessary.
         if parameter_subset is None:
             parameter_subset = self.param_numbers
-        
+
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
-        
+
         # Generate set of distinct colors for plotting.
         num_params = len(parameter_subset)
         param_colors = _color_list_from_num_of_params(num_params)
-        
+
         if self.params_generations.size == 0:
             self.log.warning('Unable to plot DE: params vs generations as the initial generation did not complete.')
             return
-        
+
         global figure_counter, generation_label, scale_param_label, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
-        
+
         artists=[]
         for ind in range(num_params):
             param_index = parameter_subset[ind]
@@ -733,25 +733,25 @@ class DifferentialEvolutionVisualizer():
             plt.plot(self.gen_plot,self.params_generations[:,:,param_index].flatten(),marker='o',linestyle='',color=color)
             artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
             plt.ylim((0,1))
-        
-        plt.title('Differential evolution: Params vs generation number.') 
+
+        plt.title('Differential evolution: Params vs generation number.')
         plt.xlabel(generation_label)
-        plt.ylabel(scale_param_label) 
+        plt.ylabel(scale_param_label)
         legend_labels = mlu._generate_legend_labels(
             parameter_subset,
             self.param_names,
         )
         plt.legend(artists, legend_labels ,loc=legend_loc)
-        
+
 def create_gaussian_process_learner_visualizations(filename,
                                                    file_type=None,
                                                    **kwargs):
     '''
     Runs the plots from a gaussian process learner file.
-    
+
     Args:
         filename (String): Filename for the gaussian process learner archive.
-        
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
@@ -761,83 +761,83 @@ def create_gaussian_process_learner_visualizations(filename,
     '''
     visualization = GaussianProcessVisualizer(filename, file_type=file_type)
     visualization.create_visualizations(**kwargs)
-    
+
 class GaussianProcessVisualizer(mll.GaussianProcessLearner):
     '''
     GaussianProcessVisualizer extends of GaussianProcessLearner, designed not to be used as a learner, but to instead post process a GaussianProcessLearner archive file and produce useful data for visualization of the state of the learner. Fixes the Gaussian process hyperparameters to what was last found during the run.
-    
+
     Args:
         filename (String): Filename of the GaussianProcessLearner archive.
-    
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
-      
+
     '''
-    
+
     def __init__(self, filename, file_type=None, **kwargs):
-        
+
         super(GaussianProcessVisualizer, self).__init__(gp_training_filename = filename,
                                                         gp_training_file_type = file_type,
                                                         gp_training_override_kwargs=True,
                                                         update_hyperparameters = False,
                                                         **kwargs)
-        
+
         self.log = logging.getLogger(__name__)
-        
+
         #Trust region
         self.has_trust_region = bool(np.array(self.training_dict['has_trust_region']))
         self.trust_region = np.squeeze(np.array(self.training_dict['trust_region'], dtype=float))
-        
+
         self.fit_gaussian_process()
-        
+
         self.param_numbers = np.arange(self.num_params)
         self.log_length_scale_history = np.log10(np.array(self.length_scale_history, dtype=float))
-        self.noise_level_history = np.array(self.noise_level_history) 
-        
+        self.noise_level_history = np.array(self.noise_level_history)
+
         if np.all(np.isfinite(self.min_boundary)) and np.all(np.isfinite(self.max_boundary)):
             self.finite_flag = True
             self.param_scaler = lambda p: (p-self.min_boundary)/self.diff_boundary
         else:
             self.finite_flag = False
-        
+
         if self.has_trust_region:
             self.scaled_trust_min = self.param_scaler(np.maximum(self.best_params - self.trust_region, self.min_boundary))
             self.scaled_trust_max = self.param_scaler(np.minimum(self.best_params + self.trust_region, self.max_boundary))
-        
+
         # Record value of update_hyperparameters used for optimization. Note that
         # self.update_hyperparameters is always set to False here above
         # regardless of its value during the optimization.
         self.used_update_hyperparameters = self.training_dict['update_hyperparameters']
-        
+
     def run(self):
         '''
         Overides the GaussianProcessLearner multiprocessor run routine. Does nothing but makes a warning.
         '''
         self.log.warning('You should not have executed start() from the GaussianProcessVisualizer. It is not intended to be used as a independent process. Ending.')
-    
-      
+
+
     def return_cross_sections(self, points=100, cross_section_center=None):
         '''
         Finds the predicted global minima, then returns a list of vectors of parameters values, costs and uncertainties, corresponding to the 1D cross sections along each parameter axis through the predicted global minima.
-        
+
         Keyword Args:
-            points (int): the number of points to sample along each cross section. Default value is 100. 
-            cross_section_center (array): parameter array where the centre of the cross section should be taken. If None, the parameters for the best returned cost are used.  
-        
+            points (int): the number of points to sample along each cross section. Default value is 100.
+            cross_section_center (array): parameter array where the centre of the cross section should be taken. If None, the parameters for the best returned cost are used.
+
         Returns:
             a tuple (cross_arrays, cost_arrays, uncer_arrays)
             cross_parameter_arrays (list): a list of arrays for each cross section, with the values of the varied parameter going from the minimum to maximum value.
-            cost_arrays (list): a list of arrays for the costs evaluated along each cross section about the minimum. 
-            uncertainty_arrays (list): a list of uncertainties 
-            
+            cost_arrays (list): a list of arrays for the costs evaluated along each cross section about the minimum.
+            uncertainty_arrays (list): a list of uncertainties
+
         '''
         points = int(points)
         if points <= 0:
             self.log.error('Points provided must be larger than zero:' + repr(points))
             raise ValueError
-        
+
         if cross_section_center is None:
             cross_section_center = self.best_params
         else:
@@ -845,7 +845,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             if not self.check_in_boundary(cross_section_center):
                 self.log.error('cross_section_center not in boundaries:' + repr(cross_section_center))
                 raise ValueError
-        
+
         cross_parameter_arrays = [ np.linspace(min_p, max_p, points) for (min_p,max_p) in zip(self.min_boundary,self.max_boundary)]
         scaled_cost_arrays = []
         scaled_uncertainty_arrays = []
@@ -858,8 +858,8 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         cross_parameter_arrays = np.array(cross_parameter_arrays)
         cost_arrays = self.cost_scaler.inverse_transform(np.array(scaled_cost_arrays))
         uncertainty_arrays = np.array(scaled_uncertainty_arrays) * self.cost_scaler.scale_
-        return (cross_parameter_arrays,cost_arrays,uncertainty_arrays) 
-    
+        return (cross_parameter_arrays,cost_arrays,uncertainty_arrays)
+
     def create_visualizations(self,
                               plot_cross_sections=True,
                               plot_hyperparameters_vs_fit=True,
@@ -868,10 +868,10 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
                               **kwargs):
         '''
         Runs the plots from a gaussian process learner file.
-            
+
         Keyword Args:
             plot_cross_sections (Optional [bool]): If `True` plot predicted
-                landscape cross sections, else do not. Default `True`. 
+                landscape cross sections, else do not. Default `True`.
             plot_hyperparameters_vs_fit (Optional [bool]): If `True` plot fitted
                 hyperparameters as a function of fit number, else do not.
                 Default `True`.
@@ -907,30 +907,30 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             self.param_numbers,
             max_parameters_per_plot,
         )
-        
+
         # Generate the requested plots.
         if plot_cross_sections:
             for parameter_chunk in parameter_chunks:
                 self.plot_cross_sections(
                     parameter_subset=parameter_chunk,
                 )
-            
+
         if plot_hyperparameters_vs_fit:
             for parameter_chunk in parameter_chunks:
                 self.plot_hyperparameters_vs_fit(
                     parameter_subset=parameter_chunk,
                 )
-        
+
         if plot_noise_level_vs_fit:
             self.plot_noise_level_vs_fit()
-    
+
     def _ensure_parameter_subset_valid(self, parameter_subset):
         _ensure_parameter_subset_valid(self, parameter_subset)
-    
+
     def plot_cross_sections(self, parameter_subset=None):
         '''
         Produce a figure of the cross section about best cost and parameters.
-    
+
         Args:
             parameter_subset (list-like): The indices of parameters to plot. The
                 indices should be 0-based, i.e. the first parameter is
@@ -942,14 +942,14 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         # Get default value for parameter_subset if necessary.
         if parameter_subset is None:
             parameter_subset = self.param_numbers
-        
+
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
-        
+
         # Generate set of distinct colors for plotting.
         num_params = len(parameter_subset)
         param_colors = _color_list_from_num_of_params(num_params)
-        
+
         global figure_counter, legend_loc
         figure_counter += 1
         plt.figure(figure_counter)
@@ -982,15 +982,15 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             parameter_subset,
             self.param_names,
         )
-        plt.legend(artists, legend_labels ,loc=legend_loc)    
-    
+        plt.legend(artists, legend_labels ,loc=legend_loc)
+
     '''
     Method is currently not supported. Of questionable usefulness. Not yet deleted.
-        
+
     def plot_all_minima_vs_cost(self):
-        
+
         #Produce figure of the all the local minima versus cost.
-        
+
         if not self.has_all_minima:
             self.find_all_minima()
         global figure_counter, legend_loc
@@ -1049,10 +1049,10 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         # Get default value for parameter_subset if necessary.
         if parameter_subset is None:
             parameter_subset = self.param_numbers
-        
+
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
-        
+
         # Get the indices corresponding to the number of fits. If
         # update_hyperparameters was set to False, then we'll say that there
         # were zero fits of the hyperparameters.
@@ -1062,15 +1062,15 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         else:
             fit_numbers = [0]
             log_length_scale_history = np.log10(np.array([self.length_scale], dtype=float))
-        
+
         # Generate set of distinct colors for plotting.
         num_params = len(parameter_subset)
         param_colors = _color_list_from_num_of_params(num_params)
-        
+
         global figure_counter, fit_label, legend_loc, log_length_scale_label
         figure_counter += 1
         plt.figure(figure_counter)
-        
+
         if type(self.length_scale) is float:
             # First treat the case of an isotropic kernel with one length scale
             # shared by all parameters.
@@ -1085,14 +1085,14 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
                 color = param_colors[ind]
                 plt.plot(fit_numbers, log_length_scale_history[:,param_index],'o',color=color)
                 artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
-                
+
             legend_labels = mlu._generate_legend_labels(
                 parameter_subset,
                 self.param_names,
             )
             plt.legend(artists, legend_labels ,loc=legend_loc)
             plt.title('GP Learner: Log of length scales vs fit number.')
-        
+
         plt.xlabel(fit_label)
         plt.ylabel(log_length_scale_label)
 
@@ -1122,10 +1122,10 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         are run each generation. Therefore the number of fits is less than the
         number of runs.
         '''
-        # Make plot of noise level vs run number if cost has noise. 
+        # Make plot of noise level vs run number if cost has noise.
         if self.cost_has_noise:
             global figure_counter, fit_label, noise_label
-            
+
             if self.used_update_hyperparameters:
                 noise_level_history = self.noise_level_history
                 fit_numbers = np.arange(1, len(noise_level_history)+1)
@@ -1141,17 +1141,17 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
             plt.plot(fit_numbers, noise_level_history,'o',color='k')
             plt.xlabel(fit_label)
             plt.ylabel(noise_label)
-            plt.title('GP Learner: Noise level vs fit number.')     
-            
+            plt.title('GP Learner: Noise level vs fit number.')
+
 def create_neural_net_learner_visualizations(filename,
                                              file_type=None,
                                              **kwargs):
     '''
     Creates plots from a neural net's learner file.
-    
+
     Args:
         filename (String): Filename for the neural net learner archive.
-        
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
@@ -1162,64 +1162,64 @@ def create_neural_net_learner_visualizations(filename,
     visualization = NeuralNetVisualizer(filename, file_type=file_type)
     visualization.create_visualizations(**kwargs)
 
-            
+
 class NeuralNetVisualizer(mll.NeuralNetLearner):
     '''
-    NeuralNetVisualizer extends of NeuralNetLearner, designed not to be used as a learner, but to instead post process a NeuralNetLearner archive file and produce useful data for visualization of the state of the learner. 
-    
+    NeuralNetVisualizer extends of NeuralNetLearner, designed not to be used as a learner, but to instead post process a NeuralNetLearner archive file and produce useful data for visualization of the state of the learner.
+
     Args:
         filename (String): Filename of the NeuralNetLearner archive.
-    
+
     Keyword Args:
         file_type (String): Can be 'mat' for matlab, 'pkl' for pickle or 'txt'
             for text. If set to None, then the type will be determined from the
             extension in filename. Default None.
     '''
-    
+
     def __init__(self, filename, file_type = None, **kwargs):
-        
-        
-        
+
+
+
         super(NeuralNetVisualizer, self).__init__(nn_training_filename = filename,
                                                   nn_training_file_type = file_type,
                                                   update_hyperparameters = False,
                                                   **kwargs)
-        
+
         self.log = logging.getLogger(__name__)
-        
+
         #Trust region
         self.has_trust_region = bool(np.array(self.training_dict['has_trust_region']))
         self.trust_region = np.squeeze(np.array(self.training_dict['trust_region'], dtype=float))
-        
+
         self.import_neural_net()
-        
+
         if np.all(np.isfinite(self.min_boundary)) and np.all(np.isfinite(self.max_boundary)):
             self.finite_flag = True
             self.param_scaler = lambda p: (p-self.min_boundary)/self.diff_boundary
         else:
             self.finite_flag = False
-        
+
         if self.has_trust_region:
             self.scaled_trust_min = self.param_scaler(np.maximum(self.best_params - self.trust_region, self.min_boundary))
             self.scaled_trust_max = self.param_scaler(np.minimum(self.best_params + self.trust_region, self.max_boundary))
-            
+
         self.param_numbers = np.arange(self.num_params)
-        
+
     def run(self):
         '''
         Overides the GaussianProcessLearner multiprocessor run routine. Does nothing but makes a warning.
         '''
         self.log.warning('You should not have executed start() from the GaussianProcessVisualizer. It is not intended to be used as a independent process. Ending.')
-    
+
     def create_visualizations(self,
                               plot_cross_sections=True,
                               max_parameters_per_plot=None):
         '''
         Creates plots from a neural net's learner file.
-            
+
         Keyword Args:
             plot_cross_sections (Optional [bool]): If True plot predicted
-                landscape cross sections, else do not. Default True. 
+                landscape cross sections, else do not. Default True.
             max_parameters_per_plot (Optional [int]): The maximum number of
                 parameters to include in plots that display the values of
                 parameters. If the number of parameters is larger than
@@ -1232,36 +1232,36 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
             self.param_numbers,
             max_parameters_per_plot,
         )
-        
+
         if plot_cross_sections:
             for parameter_chunk in parameter_chunks:
                 self.do_cross_sections(parameter_subset=parameter_chunk)
-                
+
         self.plot_surface()
         self.plot_density_surface()
         self.plot_losses()
-    
-      
+
+
     def return_cross_sections(self, points=100, cross_section_center=None):
         '''
         Finds the predicted global minima, then returns a list of vectors of parameters values, costs and uncertainties, corresponding to the 1D cross sections along each parameter axis through the predicted global minima.
-        
+
         Keyword Args:
-            points (int): the number of points to sample along each cross section. Default value is 100. 
-            cross_section_center (array): parameter array where the centre of the cross section should be taken. If None, the parameters for the best returned cost are used.  
-        
+            points (int): the number of points to sample along each cross section. Default value is 100.
+            cross_section_center (array): parameter array where the centre of the cross section should be taken. If None, the parameters for the best returned cost are used.
+
         Returns:
             a tuple (cross_arrays, cost_arrays, uncer_arrays)
             cross_parameter_arrays (list): a list of arrays for each cross section, with the values of the varied parameter going from the minimum to maximum value.
-            cost_arrays (list): a list of arrays for the costs evaluated along each cross section about the minimum. 
-            uncertainty_arrays (list): a list of uncertainties 
-            
+            cost_arrays (list): a list of arrays for the costs evaluated along each cross section about the minimum.
+            uncertainty_arrays (list): a list of uncertainties
+
         '''
         points = int(points)
         if points <= 0:
             self.log.error('Points provided must be larger than zero:' + repr(points))
             raise ValueError
-        
+
         if cross_section_center is None:
             cross_section_center = self.best_params
         else:
@@ -1269,7 +1269,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
             if not self.check_in_boundary(cross_section_center):
                 self.log.error('cross_section_center not in boundaries:' + repr(cross_section_center))
                 raise ValueError
-        
+
         res = []
         for net_index in range(self.num_nets):
             cross_parameter_arrays = [ np.linspace(min_p, max_p, points) for (min_p,max_p) in zip(self.min_boundary,self.max_boundary)]
@@ -1283,14 +1283,14 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
             cost_arrays = self.cost_scaler.inverse_transform(np.array(scaled_cost_arrays))
             res.append((cross_parameter_arrays, cost_arrays))
         return res
-    
+
     def _ensure_parameter_subset_valid(self, parameter_subset):
         _ensure_parameter_subset_valid(self, parameter_subset)
 
     def do_cross_sections(self, parameter_subset=None):
         '''
         Produce a figure of the cross section about best cost and parameters.
-    
+
         Args:
             parameter_subset (list-like): The indices of parameters to plot. The
                 indices should be 0-based, i.e. the first parameter is
@@ -1302,20 +1302,20 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         # Get default value for parameter_subset if necessary.
         if parameter_subset is None:
             parameter_subset = self.param_numbers
-        
+
         # Make sure that the provided parameter_subset is acceptable.
         self._ensure_parameter_subset_valid(parameter_subset)
-        
+
         # Generate set of distinct colors for plotting.
         num_params = len(parameter_subset)
         param_colors = _color_list_from_num_of_params(num_params)
-        
+
         # Generate labels for legends.
         legend_labels = mlu._generate_legend_labels(
             parameter_subset,
             self.param_names,
         )
-        
+
         points = 100
         rel_params = np.linspace(0,1,points)
         all_cost_arrays = [a for _,a in self.return_cross_sections(points=points)]
@@ -1423,7 +1423,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
     def plot_losses(self):
         '''
         Produce a figure of the loss as a function of epoch for each net.
-        
+
         The loss is the mean-squared fitting error of the neural net plus the
         regularization loss, which is the regularization coefficient times the
         mean L2 norm of the neural net weight arrays (without the square root).
@@ -1434,7 +1434,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         number of epochs per fit varies, and may be different for different
         nets. The loss will generally increase at the begining of each fit as
         new data points will have been added.
-        
+
         Also note that a lower loss isn't always better; a loss that is too low
         can be a sign of overfitting.
         '''
@@ -1443,11 +1443,11 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         fig = plt.figure(figure_counter)
 
         all_losses = self.get_losses()
-        
+
         # Generate set of distinct colors for plotting.
         num_nets = len(all_losses)
         net_colors = _color_list_from_num_of_params(num_nets)
-        
+
         artists=[]
         legend_labels=[]
         for ind, losses in enumerate(all_losses):


### PR DESCRIPTION
We plan on removing trailing whitespace from all of the files. I've done a few here to avoid merge conflicts in files that I plan to modify in some PRs soon, likely before the big whitespace removal .

Changes proposed in this pull request:

- Removed trailing whitespace in `docs/examples.rst`, `mloop/learners.py`, `mloop/neuralnet.py`, and `mloop/visualizations.py`.

