### PR TITLE
Fixed indentation on a comment in random_complete_config.txt

### DIFF
--- a/examples/random_complete_config.txt
+++ b/examples/random_complete_config.txt
@@ -9,6 +9,6 @@ controller_type = 'random'
 num_params = 2                    #number of parameters
 min_boundary = [1.2, -2]          #minimum boundary
 max_boundary = [10.0, 4]          #maximum boundary
-param_names = ['a', 'b']               #names for parameters
+param_names = ['a', 'b']          #names for parameters
 trust_region = [0.2, 0.5]         #maximum move distance from best params
 first_params = [5.1, -1.0]        #first parameters to try


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix indentation on one of the comments in `random_complete_config.txt.`.
