### PR TITLE
Cross validation enhancements

### DIFF
--- a/docs/visualizations.rst
+++ b/docs/visualizations.rst
@@ -110,7 +110,16 @@ Neural Net
   Note that an "epoch" here is not the same as a run of the experiment.
   One epoch corresponds to one iteration over the full data set while fitting a neural net.
   Generally the fitting routine will go through many epochs during one fit, and the number of epochs per fit will vary.
-  
+
+- **Neural Net Learner: Regularization History.**
+  The neural nets use L2 regularization to smooth their predicted landscapes in an attempt to avoid overfitting the data.
+  The strength of the regularization is set by the regularization coefficient, which is a hyperparameter that is tuned during the optimization if ``update_hyperparameters`` is set to ``True``.
+  Generally larger regularization coefficient values force the landscape to be smoother while smaller values allow it to vary more quickly.
+  A value too large can lead to underfitting while a value too small can lead to overfitting.
+  The ideal regularization coefficient value will depend on many factors, such as the shape of the actual cost landscape, the SNR of the measured costs, and even the number of measured costs.
+  This method plots the initial regularization coefficient value and the optimal values found for the regularization coefficient when performing the hyperparameter tuning.
+  One curve showing the history of values used for the regularization coefficient is plotted for each neural net.
+  If ``update_hyperparameters`` was set to ``False`` during the optimization, then only the initial default value will be plotted.
 
 Differential Evolution
 ----------------------

--- a/examples/neural_net_complete_config.txt
+++ b/examples/neural_net_complete_config.txt
@@ -19,6 +19,7 @@ learner_archive_filename = 'a_word'    #filename of neural net learner archive, 
 learner_archive_file_type = 'mat'      #file type of neural net learner archive
 predict_global_minima_at_end  = True   #find predicted global minima at end 
 no_delay = True                        #whether to wait for the GP to make predictions or not. Default True (do not wait)  
+update_hyperparameters = False         #whether hyperparameters should be tuned to avoid overfitting. Default False.
 
 #Training source options
 training_type = 'random'               #training type can be random, differential_evolution, or nelder_mead

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2069,6 +2069,11 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         end_event (event): Event to trigger end of learner.
 
     Keyword Args:
+        update_hyperparameters (Optional [bool]): Whether the hyperparameters
+            used to prevent overfitting should be tuned by trying out different
+            values. Setting to `True` can reduce overfitting of the model, but
+            can slow down the fitting due to the computational cost of trying
+            different values. Default `False`.
         nn_training_filename (Optional [str]): The name of a learner archive
             from a previous optimization from which to extract past results for
             use in the current optimization. If `None`, no past results will be
@@ -2108,6 +2113,7 @@ class NeuralNetLearner(MachineLearner, mp.Process):
     _ARCHIVE_TYPE = 'neural_net_learner'
 
     def __init__(self,
+                 update_hyperparameters=False,
                  nn_training_filename =None,
                  nn_training_file_type =None,
                  **kwargs):
@@ -2143,11 +2149,15 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         self.num_nets = 3
         self.generation_num = 3
 
+        #Optional user set variables
+        self.update_hyperparameters = bool(update_hyperparameters)
+
         self.archive_dict.update({'archive_type':self._ARCHIVE_TYPE,
                                   'generation_num':self.generation_num,
                                   'search_precision':self.search_precision,
                                   'parameter_searches':self.parameter_searches,
                                   'bad_uncer_frac':self.bad_uncer_frac,
+                                  'update_hyperparameters':self.update_hyperparameters,
                                   'trust_region':self.trust_region,
                                   'has_trust_region':self.has_trust_region,
                                   'predict_global_minima_at_end':self.predict_global_minima_at_end})
@@ -2159,6 +2169,7 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         self.neural_net = [
             mlnn.NeuralNet(
                 num_params=self.num_params,
+                fit_hyperparameters=self.update_hyperparameters,
                 learner_archive_dir=self.learner_archive_dir,
                 start_datetime=self.start_datetime)
             for _ in range(self.num_nets)

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2402,3 +2402,24 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         for n in self.neural_net:
             all_losses.append(n.get_losses())
         return all_losses
+
+    def get_regularization_histories(self):
+        '''
+        Get the regularization coefficient values used by the nets.
+
+        Returns:
+            list of list of float: The values used by the neural nets for the
+                regularization coefficient. There is one list per net, which
+                includes all of the regularization coefficient values used by
+                that net during the optimization. If the optimization was run
+                with `update_hyperparameters` set to `False`, then each net's
+                list will only have one entry, namely the initial default value
+                for the regularization coefficient. If the optimization was run
+                with `updated_hyperparameters` set to `True` then the list will
+                also include the optimal values for the regularization
+                coefficient determined during each hyperparameter fitting.
+        '''        
+        regularization_histories = []
+        for net in self.neural_net:
+            regularization_histories.append(net.regularization_history)
+        return regularization_histories

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -657,6 +657,7 @@ class NeuralNet():
             n_fits = len(all_params)
             n_hyperfit = int(n_fits / 20.0)  # int() rounds down.
             if n_hyperfit > self.last_hyperfit:
+                self.log.info("Tuning regularization coefficient value.")
                 self.last_hyperfit = n_hyperfit
 
                 # Fit regularisation
@@ -694,6 +695,9 @@ class NeuralNet():
                 cv_losses = []
                 best_cv_loss = np.inf
                 for r in regularizations:
+                    self.log.debug(
+                        "Testing regularization value {r}...".format(r=r)
+                    )
                     net = self._make_net(r)
                     net.init()
                     net.fit(train_params, train_costs, self.initial_epochs)

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -646,13 +646,19 @@ class NeuralNet():
 
                 # Fit regularisation
 
-                # Split the data into training and cross validation
+                # Split the data into training and cross validation randomly
                 training_fraction = 0.9
-                split_index = int(training_fraction * len(all_params))
-                train_params = all_params[:split_index]
-                train_costs = all_costs[:split_index]
-                cv_params = all_params[split_index:]
-                cv_costs = all_costs[split_index:]
+                n_observations = len(all_costs)
+                split_index = int(training_fraction * n_observations)
+                indices = np.random.permutation(n_observations)
+                # Extract the training dataset.
+                train_indices = indices[:split_index]
+                train_params = all_params[train_indices]
+                train_costs = all_costs[train_indices]
+                # Extract the cross validation dataset.
+                cv_indices = indices[split_index:]
+                cv_params = all_params[cv_indices]
+                cv_costs = all_costs[cv_indices]
 
                 orig_cv_loss = self.net.cross_validation_loss(cv_params, cv_costs)
                 best_cv_loss = orig_cv_loss

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -440,6 +440,7 @@ class NeuralNet():
             default value for the SingleNeuralNet class will be used. Default
             None.
     '''
+    _DEFAULT_NET_REG = 1e-8
 
     def __init__(self,
                  num_params = None,
@@ -464,7 +465,7 @@ class NeuralNet():
 
         # Variables for tracking the current state of hyperparameter fitting.
         self.last_hyperfit = 0
-        self.last_net_reg = 1e-8
+        self.last_net_reg = self._DEFAULT_NET_REG
         self.regularization_history = [self.last_net_reg]
 
         # The samples used to fit the scalers. When set, this will be a tuple of
@@ -688,13 +689,12 @@ class NeuralNet():
                 # Try a bunch of different regularisation parameters, switching
                 # to a new one if it does better on the cross validation set
                 # than the old one.
-                previous_regularization = self.last_net_reg
-                regularizations = [0.001, 0.01, 0.1, 1, 10]
-                if previous_regularization not in regularizations:
-                    regularizations.append(previous_regularization)
+                regularizations = [self._DEFAULT_NET_REG]
+                regularizations.extend(np.logspace(-5, 1, 7))
                 cv_losses = []
                 best_cv_loss = np.inf
                 for r in regularizations:
+                    r = float(r)
                     self.log.debug(
                         "Testing regularization value {r}...".format(r=r)
                     )

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -661,6 +661,12 @@ class NeuralNet():
 
                 # Fit regularisation
 
+                # May as well re-fit the cost and parameter scalers since a new
+                # net will be re-created from scratch. This keeps the scaled
+                # costs and parameters ~1.
+                self.scaler_samples = (all_params.copy(), all_costs.copy())
+                self._fit_scaler()
+
                 # Split the data into training and cross validation randomly
                 training_fraction = 0.9
                 n_observations = len(all_costs)

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -654,9 +654,10 @@ class NeuralNet():
         all_params, all_costs = self._scale_params_and_cost_list(all_params, all_costs)
 
         if self.fit_hyperparameters:
-            # Every 20 runs, re-fit the hyperparameters.
+            # Re-fit the hyperparameters every runs_per_hyperparameter_fit runs.
+            runs_per_hyperparameter_fit = 100.0
             n_fits = len(all_params)
-            n_hyperfit = int(n_fits / 20.0)  # int() rounds down.
+            n_hyperfit = int(n_fits / runs_per_hyperparameter_fit)  # int() rounds down.
             if n_hyperfit > self.last_hyperfit:
                 self.log.info("Tuning regularization coefficient value.")
                 self.last_hyperfit = n_hyperfit

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -298,7 +298,7 @@ class SingleNeuralNet():
             params (array): array of parameter arrays
             costs (array): array of costs (associated with the corresponding parameters)
         '''
-        return self.tf_session.run(self.loss_total,
+        return self.tf_session.run(self.loss_raw,
                                   feed_dict={self.input_placeholder: params,
                                   self.output_placeholder: [[c] for c in costs],
                                   })

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1293,7 +1293,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         self.plot_surface()
         self.plot_density_surface()
         self.plot_losses()
-
+        self.plot_regularization_history()
 
     def return_cross_sections(self, points=100, cross_section_center=None):
         '''
@@ -1514,4 +1514,52 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         plt.xlabel("Epoch")
         plt.ylabel("Fitting Loss")
         plt.title('Loss vs Epoch')
+        plt.legend(artists, legend_labels, loc=legend_loc)
+
+    def plot_regularization_history(self):
+        '''
+        Produces a plot of the regularization coefficient values used.
+
+        The neural nets use L2 regularization to smooth their predicted
+        landscapes in an attempt to avoid overfitting the data. The strength of
+        the regularization is set by the regularization coefficient, which is a
+        hyperparameter that is tuned during the optimization if
+        `update_hyperparameters` is set to `True`. Generally larger
+        regularization coefficient values force the landscape to be smoother
+        while smaller values allow it to vary more quickly. A value too large
+        can lead to underfitting while a value too small can lead to
+        overfitting. The ideal regularization coefficient value will depend on
+        many factors, such as the shape of the actual cost landscape, the SNR of
+        the measured costs, and even the number of measured costs.
+
+        This method plots the initial regularization coefficient value and the
+        optimal values found for the regularization coefficient when performing
+        the hyperparameter tuning. One curve showing the history of values used
+        for the regularization coefficient is plotted for each neural net. If
+        `update_hyperparameters` was set to `False` during the optimization,
+        then only the initial default value will be plotted.
+        '''
+        global figure_counter
+        figure_counter += 1
+        fig = plt.figure(figure_counter)
+
+        regularization_histories = self.get_regularization_histories()
+
+        # Generate set of distinct colors for plotting.
+        num_nets = len(regularization_histories)
+        net_colors = _color_list_from_num_of_params(num_nets)
+
+        artists=[]
+        legend_labels=[]
+        for ind, regularization_history in enumerate(regularization_histories):
+            color = net_colors[ind]
+            hyperparameter_fit_numbers = np.arange(len(regularization_history))
+            plt.plot(hyperparameter_fit_numbers, regularization_history, color=color, marker='o', linestyle='-')
+            artists.append(plt.Line2D((0,1),(0,0), color=color,marker='o',linestyle=''))
+            legend_labels.append('Net {net_index}'.format(net_index=ind))
+
+        plt.yscale('log')
+        plt.xlabel("Hyperparameter Fit Number")
+        plt.ylabel("Regularization Coefficient")
+        plt.title("Regularization Tuning History")
         plt.legend(artists, legend_labels, loc=legend_loc)

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1231,9 +1231,18 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         self.has_trust_region = bool(np.array(training_dict['has_trust_region']))
         self.trust_region = np.squeeze(np.array(training_dict['trust_region'], dtype=float))
         self.nn_training_file_dir = self.training_file_dir
+        # Cost scaler
         self.cost_scaler_init_index = training_dict['cost_scaler_init_index']
         if not self.cost_scaler_init_index is None:
             self._init_cost_scaler()
+        # update_hyperparameters wasn't used or saved by M-LOOP versions 3.1.1
+        # and below, but effectively was set to False. Default to that value for
+        # archives that don't have an entry for it.
+        update_hyperparameters = training_dict.get(
+            'update_hyperparameters',
+            False,
+        )
+        self.update_hyperparameters = bool(update_hyperparameters)
 
         self.import_neural_net()
 


### PR DESCRIPTION
Attempts to fix #80. See that issue for discussion and tests that led to the changes here.

Changes proposed in this pull request:

- Add a user option `update_hyperparameters` for neural net learner optimizations which instructs the learner to tune the regularization coefficient using cross validation.
  - It defaults to `False`, which retains the previous behavior.
- Log the values used for the regularization coefficient and add `NeuralNetVisualizer.plot_regularization_history()` to plot those values.
- Use `loss_raw` instead of `loss_total` in `SingleNeuralNet.cross_validation_loss()`
  - This makes comparison of the loss between nets with different regularization coefficients more fair.
- Create a new net to test the previous regularization coefficient value rather than using the existing net.
  - The existing net has been trained on data that ends up in the cross validation set which gives it a misleadingly low cross validation loss. Creating a new net and only training it on the training data subset puts it on level footing with the nets that try out the other possible regularization coefficient values.
  - This also means that the net is re-initialized every time the hyperparameter tuning is run, even if the regularization coefficient doesn't change. That has the consequence that the early stopping condition has a better chance of preventing overfitting as well, as seen [in this comment](https://github.com/michaelhush/M-LOOP/issues/80#issue-739900705).
- Use a randomized subset of observations for the cross validation set.
- Take the regularization coefficient that leads to the lowest cross validation loss regardless of how small the improvement over the previous regularization coefficient value is.
  - Previously it was only changed if the cross validation loss improved by a factor of 10. However in the tests in #80 the change in cross validation loss between regularization coefficient values that were good and those that led to overfitting/underfitting was often much smaller than a factor of 10.
- Add more values to try for the regularization coefficient when tuning it.
- Re-fit the cost and parameter scalers when the neural net hyperparameter tuning runs.
  - This ensures that the scaled costs and parameters are always ~1 and it takes very little time to run.
- Run the hyperparameter tuning for each net once every 100 runs instead of once every 20 runs.
  - This was done to speed up optimizations as the hyperparameter tuning is fairly slow. [It increased the time](https://github.com/michaelhush/M-LOOP/issues/80#issuecomment-747266315) to do 1000 iterations of a simulated optimization from about 0.5 hours to 5.5 hours when running every 20 runs and trying about 10 different regularization values.
- `SingleNeuralNet._loss()` now returns `loss_reg` as well which can be helpful for debugging.
- Update docstrings and documentation to reflect changes.
- Change 3

When `update_hyperparameters` is set to `False` the behavior is essentially the same as before. The main difference is that the plot from `NeuralNetVisualizer.plot_regularization_history()` will be displayed and show just the initial/constant regularization coefficient value.
