### PR TITLE
Fix visualizer parameter names bug

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -810,6 +810,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         training_dict = self.training_dict
 
         # Optimization options not loaded by parent class.
+        self.param_names = mlu._param_names_from_file_dict(training_dict)
         self.cost_has_noise = bool(training_dict['cost_has_noise'])
         #Trust region
         self.has_trust_region = bool(np.array(training_dict['has_trust_region']))
@@ -1227,6 +1228,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         training_dict = self.training_dict
 
         # Archive data not loaded by parent class
+        self.param_names = mlu._param_names_from_file_dict(training_dict)
         #Trust region
         self.has_trust_region = bool(np.array(training_dict['has_trust_region']))
         self.trust_region = np.squeeze(np.array(training_dict['trust_region'], dtype=float))


### PR DESCRIPTION
Fixed bug introduced in #90 which made `GaussianProcessVisualizer` and `NeuralNetVisualizer` use the default value for `param_names` instead of loading it from the archive.

The parameter names are taken from the optional keyword argument `param_names` when creating a `GaussianProcessLearner` or `NeuralNetLearner`, even if a training archive which has an entry for `param_names` is provided. The visualizers need to overwrite the value from the keyword argument with the value from the archive. This PR makes them do so.