### PR TITLE
Use training archive regularization coefficient values

### DIFF
--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -439,6 +439,11 @@ class NeuralNet():
             filenames when saving the neural nets. If set to None, then the
             default value for the SingleNeuralNet class will be used. Default
             None.
+        regularization_coefficient (Optional float): The initial value for the
+            coefficient used to weight the regularization cost when calculating
+            the total loss. If set to `None` then the default value of `1e-8`
+            will be used. Note that the coefficient's value will generally
+            change if `fit_hyperparameters` is set to `True`. Default `None`.
     '''
     _DEFAULT_NET_REG = 1e-8
 
@@ -446,7 +451,9 @@ class NeuralNet():
                  num_params = None,
                  fit_hyperparameters = False,
                  learner_archive_dir = None,
-                 start_datetime = None):
+                 start_datetime = None,
+                 regularization_coefficient=None,
+                 ):
 
         self.log = logging.getLogger(__name__)
         self.log.info('Initialising neural network impl')
@@ -465,7 +472,10 @@ class NeuralNet():
 
         # Variables for tracking the current state of hyperparameter fitting.
         self.last_hyperfit = 0
-        self.last_net_reg = self._DEFAULT_NET_REG
+        if regularization_coefficient is None:
+            self.last_net_reg = self._DEFAULT_NET_REG
+        else:
+            self.last_net_reg = regularization_coefficient
         self.regularization_history = [self.last_net_reg]
 
         # The samples used to fit the scalers. When set, this will be a tuple of


### PR DESCRIPTION
When starting an optimization with a neural net learner and providing a training archive for it, it can make sense to use the last regularization coefficient values from the training archive as the initial regularization coefficient values for the new nets. In particular this is a reasonable thing to do if (a) the training archive was from a neural net learner optimization so that it has regularization coefficient values stored in it and (b) the previous optimization had the same min/max boundaries.

Point (b) might not actually be necessary. I was originally thinking that changing the min/max boundaries would change how the parameters are scaled, which would change the typical length scales of the scaled cost landscape, which would in turn change the ideal value for the regularization coefficient. However the nets will restore their parameter scalers so the typical length scales of the scaled cost landscape are likely the same even if the boundaries change (unless e.g. the length scales are different in some newly allowed region of parameter-space). For now though I've set the code to only restore the regularization coefficient values from the archive if the min/max boundaries are the same, which seems reasonable. That requirement could probably be lifted in the future though.

Changes proposed in this pull request:

- Restore the values of the regularization coefficients from the training archive when using a neural net learner's archive as the training archive for a new neural net learner optimization with the same min/max boundaries.
