### PR TITLE
Add description for PyPI

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+======
+M-LOOP
+======
+
+The Machine-Learner Online Optimization Package is designed to automatically and rapidly optimize the parameters of a scientific experiment or computer controller system. See the documentation at http://m-loop.readthedocs.io/.

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,13 @@ import multiprocessing as mp
 import mloop as ml
 
 from setuptools import setup, find_packages
+from os import path
 
 def main():
+    this_directory = path.abspath(path.dirname(__file__))
+    with open(path.join(this_directory, 'DESCRIPTION.rst'), encoding='utf-8') as f:
+        long_description = f.read()
+
     setup(
         name = 'M-LOOP',
         version = ml.__version__,
@@ -37,6 +42,7 @@ def main():
         author = 'Michael R Hush',
         author_email = 'MichaelRHush@gmail.com',
         description = 'M-LOOP: Machine-learning online optimization package. A python package of automated optimization tools - enhanced with machine-learning - for quantum scientific experiments, computer controlled systems or other optimization tasks.',
+        long_description = long_description,
         license = 'MIT',
         keywords = 'automated machine learning optimization optimisation science experiment quantum',
         url = 'https://github.com/michaelhush/M-LOOP/', 


### PR DESCRIPTION
See https://test.pypi.org/project/M-LOOP/3.1.3/. I think it makes more
sense to use a separate DESCRIPTION file instead of just the README,
since the README has information about installing from source (which
somebody installing from PyPI doesn't need to know about).
