### PR TITLE
Avoid creating M-LOOP_archives directory when creating visualizers

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -131,6 +131,7 @@ class Learner():
             raise ValueError(msg)
         if learner_archive_filename is None:
             self.learner_archive_filename = None
+            self.learner_archive_dir = None
         else:
             # Store self.learner_archive_filename without any path, but include
             # any path components in learner_archive_filename when constructing

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -804,6 +804,7 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
                                                         gp_training_file_type = file_type,
                                                         gp_training_override_kwargs=True,
                                                         update_hyperparameters = False,
+                                                        learner_archive_filename=None,
                                                         **kwargs)
 
         self.log = logging.getLogger(__name__)
@@ -1254,6 +1255,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         super(NeuralNetVisualizer, self).__init__(nn_training_filename = filename,
                                                   nn_training_file_type = file_type,
                                                   update_hyperparameters = False,
+                                                  learner_archive_filename=None,
                                                   **kwargs)
 
         self.log = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #105 .

Changes proposed in this pull request:

- Make `GaussianProcessVisualizer` and `NeuralNetVisualizer` specify `learner_archive_filename=None` when calling their parent `__init__()` methods.
  - This prevents `Learner.__init__()` from creating an `M-LOOP_archives` directory in the current working directory.
- `Learner.__init__()` now sets `self.learner_archive_dir=None` when `learner_archive_filename` is `None`.
  - This is necessary for `NeuralNetLearner.import_neural_net()` to work.

@qctrl/support