### PR TITLE
Update landscape_vis.py

### DIFF
--- a/tools/landscape_vis.py
+++ b/tools/landscape_vis.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 import argparse
 
-parser = argparse.ArgumentParser(description='Plot cross sections of the predicted landscape, and optionally upload them via plotly. Must be run from the same directory as M-LOOP was run.')
+parser = argparse.ArgumentParser(description='Plot cross sections of the predicted landscape. Must be run from the same directory as M-LOOP was run.')
 parser.add_argument("controller_filename")
 parser.add_argument("learner_filename")
-parser.add_argument("learner_type")
-parser.add_argument("-u","--upload",action="store_true",help="upload plots to the interwebs")
 args = parser.parse_args()
 
 import mloop.visualizations as mlv
@@ -14,4 +12,4 @@ import logging
 
 mlu.config_logger(log_filename=None, console_log_level=logging.DEBUG)
 
-mlv.show_all_default_visualizations_from_archive(args.controller_filename, args.learner_filename, args.learner_type, upload_cross_sections=args.upload)
+mlv.show_all_default_visualizations_from_archive(args.controller_filename, args.learner_filename)


### PR DESCRIPTION
Fixes #108.

In `tools/landscape_vis.py`, removed mentions of (now deprecated) plotly support and updated usage of `mlv.show_all_default_visualizations_from_archive()` (no longer need `learner_type`).

