### PR TITLE
Deprecate controller_type argument of some visualization functions

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -141,8 +141,7 @@ def show_all_default_visualizations_from_archive(controller_filename,
             learner visualizer's __init__() method. If set to None, no
             additional keyword arguments will be passed. Default None.
     '''
-    # Issue DeprecationWarning about controller_type if the user provided a
-    # value for it.
+    # Issue warning about controller_type if the user provided a value for it.
     if controller_type is not None:
         warnings.warn(
             ("The controller_type argument is now deprecated and has no "
@@ -200,8 +199,7 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
         visualizer: An instance of the appropriate visualizer class for plotting
             data from filename.
     '''
-    # Issue DeprecationWarning about controller_type if the user provided a
-    # value for it.
+    # Issue warning about controller_type if the user provided a value for it.
     if controller_type is not None:
         warnings.warn(
             ("The controller_type argument is now deprecated and has no "

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -115,11 +115,10 @@ def show_all_default_visualizations_from_archive(controller_filename,
             archive.
 
     Keyword Args:
-        controller_type (str): The value of controller_type type used in the
-            optimization corresponding to the learner learner archive, e.g.
-            'gaussian_process', 'neural_net', or 'differential_evolution'. If
-            set to None then controller_type will be determined automatically.
-            Default None.
+        controller_type (NoneType): This argument is now deprecated and has no
+            effect. Do not provide a value for controller_type; it will be
+            removed in a future version of M-LOOP. If set to anything other than
+            None, a warning will be issued. Default None.
         show_plots (bool): Determine whether to run plt.show() at the end or
             not. For debugging. Default True.
         max_parameters_per_plot (Optional [int]): The maximum number of
@@ -142,6 +141,15 @@ def show_all_default_visualizations_from_archive(controller_filename,
             learner visualizer's __init__() method. If set to None, no
             additional keyword arguments will be passed. Default None.
     '''
+    # Issue DeprecationWarning about controller_type if the user provided a
+    # value for it.
+    if controller_type is not None:
+        warnings.warn(
+            ("The controller_type argument is now deprecated and has no "
+             "effect. It will be removed in a future version of M-LOOP. Do not "
+             "provide a value for controller_type.")
+        )
+
     # Set default value for controller_visualization_kwargs if necessary.
     if controller_visualization_kwargs is None:
         controller_visualization_kwargs = {}
@@ -181,11 +189,10 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
         filename (String): Filename of the learner archive.
 
     Keyword Args:
-        controller_type (String): The type of controller used during the
-            optimization that created the provided learner archive. Options
-            include 'gaussian_process', 'neural_net', and
-            'differential_evolution'. If set to None, then controller_type will
-            be determined automatically from the archive. Default None.
+        controller_type (NoneType): This argument is now deprecated and has no
+            effect. Do not provide a value for controller_type; it will be
+            removed in a future version of M-LOOP. If set to anything other than
+            None, a warning will be issued. Default None.
         **kwargs: Additional keyword arguments are passed to the visualizer's
             __init__() method.
 
@@ -193,9 +200,17 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
         visualizer: An instance of the appropriate visualizer class for plotting
             data from filename.
     '''
-    # Automatically determine controller_type if necessary.
-    if controller_type is None:
-        controller_type = mlu.get_controller_type_from_learner_archive(filename)
+    # Issue DeprecationWarning about controller_type if the user provided a
+    # value for it.
+    if controller_type is not None:
+        warnings.warn(
+            ("The controller_type argument is now deprecated and has no "
+             "effect. It will be removed in a future version of M-LOOP. Do not "
+             "provide a value for controller_type.")
+        )
+
+    # Automatically determine controller_type.
+    controller_type = mlu.get_controller_type_from_learner_archive(filename)
 
     # Create an instance of the appropriate visualizer class for the archive.
     log = logging.getLogger(__name__)


### PR DESCRIPTION
I just noticed today that after #50, `mloop.visualizations.show_all_default_visualizations_from_archive()` no longer actually uses the value of its optional `controller_type` argument. Instead the controller type (e.g. `'neural_net'` or `'gaussian_process'`) is determined automatically from the archive and the user's value is ignored. The function only works if the correct value is passed for `controller_type`, so allowing the user to specify it doesn't provide any extra flexibility. I thought it made more sense to deprecate that argument rather than to modify the code to use the user's value.

The function `mloop.visualizationscreate_learner_visualizer_from_archive()` also supported an optional `controller_type` argument (there its value is actually used if provided). However since its value can and should be automatically determined, I decided it makes sense to deprecate it there as well.

I've left the `controller_type` argument in the function definitions so that user code won't be broken. Instead a deprecation warning will be issued if the user passes a value for `controller_type`, indicating that the argument will be removed in the future.


Changes proposed in this pull request:

- Deprecate the now-unnecessary `controller_type` argument of `mloop.visualizations.show_all_default_visualizations_from_archive()` and `mloop.visualizationscreate_learner_visualizer_from_archive()`.
    - The argument is still present in the code so that user code won't break. Instead a deprecation warning will be issued if the user passes a value for `controller_type`.
    - Its value is instead determined automatically from the archive.
