### PR TITLE
Removed uses of previously-removed gp_training_override_kwargs option

### DIFF
--- a/examples/gaussian_process_complete_config.txt
+++ b/examples/gaussian_process_complete_config.txt
@@ -31,6 +31,5 @@ training_type = 'random'               #training type can be random, differentia
 first_params = [1.9, -1.0]             #first parameters to try in initial training
 gp_training_filename = None            #filename for training from previous experiment
 gp_training_file_type = 'pkl'          #training data file type
-gp_training_override_kwargs = False    #whether to override user-supplied keyword options with values set in training archive.
 
 #if you use nelder_mead for the initial training source see the CompleteNelderMeadConfig.txt for options. 

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -815,7 +815,6 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
 
         super(GaussianProcessVisualizer, self).__init__(gp_training_filename = filename,
                                                         gp_training_file_type = file_type,
-                                                        gp_training_override_kwargs=True,
                                                         update_hyperparameters = False,
                                                         learner_archive_filename=None,
                                                         **kwargs)


### PR DESCRIPTION
The `gp_training_override_kwargs` option to `GaussianProcessLearner` was removed in 845a74b9e0a34b4b17e8b832e4dc9323640ec614, which simplified how M-LOOP behaves when a training archive is provided (i.e. for some options it now uses user-supplied values if provided or the values in the training archive if not explicitly provided by the user). However, some uses of of that option were accidentally left in, and one of those caused the test `gaussian_process_complete_config` to fail. That test now passes.

Fixes #116.

Changes proposed in this pull request:

- Remove references to the (previously-removed) `gp_training_override_kwargs` argument for `GaussianProcessLearner`.

