### PR TITLE
Make M-LOOP compatible with scikit-learn 1.0.

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2092,7 +2092,12 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
                 self.predicted_best_scaled_cost = curr_best_cost
                 self.predicted_best_scaled_uncertainty = curr_best_uncer
 
-        self.predicted_best_cost = self.cost_scaler.inverse_transform(self.predicted_best_scaled_cost)
+        # Convert 1-element 1D arrays to/from 2D for scikit-learn >=1.0
+        # compatability.
+        predicted_best_cost = self.cost_scaler.inverse_transform(
+            self.predicted_best_scaled_cost.reshape(1, -1)  # 2D array.
+        )
+        self.predicted_best_cost = predicted_best_cost.reshape(1)  # 1D array.
         self.predicted_best_uncertainty = self.predicted_best_scaled_uncertainty * self.cost_scaler.scale_
 
         self.archive_dict.update({'predicted_best_parameters':self.predicted_best_parameters,
@@ -2441,7 +2446,7 @@ class NeuralNetLearner(MachineLearner, mp.Process):
                 self.predicted_best_parameters = curr_best_params
                 self.predicted_best_scaled_cost = curr_best_cost
 
-        self.predicted_best_cost = float(self.cost_scaler.inverse_transform([self.predicted_best_scaled_cost]))
+        self.predicted_best_cost = float(self.cost_scaler.inverse_transform([[self.predicted_best_scaled_cost]]))
         self.archive_dict.update({'predicted_best_parameters':self.predicted_best_parameters,
                                   'predicted_best_scaled_cost':self.predicted_best_scaled_cost,
                                   'predicted_best_cost':self.predicted_best_cost})


### PR DESCRIPTION
As pointed out in issue #120, newer scikit-learn versions error if a 1D array is passed to `StandardScaler.inverse_transform()`, so the arrays must be made 2D first.

Fixes #120.

Changes proposed in this pull request:

- Convert data to 2D arrays before using `StandardScaler.inverse_transform()`
    - This is done in `GaussianProcessLearner.find_global_minima()` and `NeuralNetLearner.find_global_minima()`
