### PR TITLE
Reduce level for some log messages in `neuralnet.py`

### DIFF
--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -241,7 +241,7 @@ class SingleNeuralNet():
             params (array): array of parameter arrays
             costs (array): array of costs (associated with the corresponding parameters)
         '''
-        self.log.info('Fitting neural network')
+        self.log.debug('Fitting neural network')
         if len(params) == 0:
             self.log.error('No data provided.')
             raise ValueError
@@ -281,7 +281,7 @@ class SingleNeuralNet():
                 if i % 10 == 0:
                     (l, ul, lr) = self._loss(params, costs)
                     self.losses_list.append(l)
-                    self.log.info(
+                    self.log.debug(
                         ("Fit neural network with total training cost {l}, "
                          "with unregularized cost {ul} and regularization cost "
                          "{lr}").format(l=l, ul=ul, lr=lr)


### PR DESCRIPTION
This PR reduces the log level from `INFO` to `DEBUG` for some log messages in `neuralnet.py`.

These log outputs contain tedious low-level information and were clogging up the terminal when the terminal log level was set to the default value of `INFO`. These particular messages aren't generally helpful to the typical user, so they should be at the `DEBUG` level.

Changes proposed in this pull request:

- Reduce level for some log messages in `neuralnet.py`
