### PR TITLE
Fix machine learner visualization cross sections range bug

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -823,6 +823,8 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         training_dict = self.training_dict
 
         # Optimization options not loaded by parent class.
+        self.min_boundary = training_dict['min_boundary']
+        self.max_boundary = training_dict['max_boundary']
         self.param_names = mlu._param_names_from_file_dict(training_dict)
         self.cost_has_noise = bool(training_dict['cost_has_noise'])
         #Trust region
@@ -1273,7 +1275,9 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         self.log = logging.getLogger(__name__)
         training_dict = self.training_dict
 
-        # Archive data not loaded by parent class
+        # Archive data not loaded by parent class.
+        self.min_boundary = self.training_dict['min_boundary']
+        self.max_boundary = self.training_dict['max_boundary']
         self.param_names = mlu._param_names_from_file_dict(training_dict)
         #Trust region
         self.has_trust_region = bool(np.array(training_dict['has_trust_region']))


### PR DESCRIPTION
Before this PR, the machine learning visualizer classes `GaussianProcessVisualizer` and `NeuralNetVisualizer` did not load the minimum and maximum boundary values from the learner archive so those took their default values. This behavior was very likely introduced by #90 as the desired behavior when creating a learner with a training archive, though I haven't explicitly checked that. The erroneous boundaries would mess up the predicted cross section plots as the cost was predicted over the default parameter value range rather than the actual parameter value range. This wasn't always immediately obvious because the plots then show the results with the x-axis rescaled from 0 to 1.

This PR modifies those visualization classes to pull the min and max boundary from the archive, which then fixes the predicted cross section plots.

Changes proposed in this pull request:

- The machine learning visualizer classes now load `min_boundary` and `max_boundary` from the learner archives and assign those values to `self.min_boundary` and `self.max_boundary` values.
  - This is necessary for the plots to predict the cost over the correct range of parameter values.
