### PR TITLE
Parameter scaling

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1934,7 +1934,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         """
 
         self.params_scaler = skp.StandardScaler(with_mean=True, with_std=True)
-        self.params_scaler.fit(scaler_samples)
+        self.params_scaler.fit(self.all_params)
 
     def fit_gaussian_process(self):
         '''

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2911,10 +2911,6 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         if net_index is None:
             net_index = nr.randint(self.num_nets)
 
-        # Initialize some attributes for keeping track of predicted results.
-        self.predicted_best_parameters = None
-        self.predicted_best_scaled_cost = float('inf')
-
         # Call self.find_next_parameters() since that method searches for the
         # predicted minimum.
         self.predicted_best_parameters = self.find_next_parameters(

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1999,7 +1999,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         self.cost_bias = self.bias_func_cost_factor[self.params_count%self.bias_func_cycle]
         self.uncer_bias = self.bias_func_uncer_factor[self.params_count%self.bias_func_cycle]
 
-    def predict_biased_cost_unscaled(self,params):
+    def predict_biased_cost_unscaled(self,scaled_params):
         '''
         Predict the biased cost at the given parameters.
         
@@ -2012,7 +2012,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         Returns:
             pred_bias_cost (float): Biased cost predicted at the given parameters
         '''
-        (pred_cost, pred_uncer) = self.gaussian_process.predict(params[np.newaxis,:], return_std=True)
+        (pred_cost, pred_uncer) = self.gaussian_process.predict(scaled_params[np.newaxis,:], return_std=True)
         return self.cost_bias*pred_cost - self.uncer_bias*pred_uncer
 
     def find_next_parameters(self):
@@ -2335,7 +2335,7 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         # scipy.optimize.minimize doesn't seem to like a 32-bit Jacobian, so we convert to 64
         return self.neural_net[net_index].predict_cost_gradient(params).astype(np.float64)
 
-    def predict_cost_unscaled(self,params,net_index=None):
+    def predict_cost_unscaled(self,scaled_params,net_index=None):
         '''
         Produces a prediction of cost from the neural net at params.
         Same a predict cost, but without the scaling
@@ -2345,9 +2345,9 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         '''
         if net_index is None:
             net_index = nr.randint(self.num_nets)
-        return self.neural_net[net_index].predict_cost_unscaled(params)
+        return self.neural_net[net_index].predict_cost_unscaled(scaled_params)
 
-    def predict_cost_gradient_unscaled(self,params,net_index=None):
+    def predict_cost_gradient_unscaled(self,scaled_params,net_index=None):
         '''
         Produces a prediction of the gradient of the cost function at params.
         Same as predict gradient, but without the scaling
@@ -2357,7 +2357,7 @@ class NeuralNetLearner(MachineLearner, mp.Process):
         if net_index is None:
             net_index = nr.randint(self.num_nets)
         # scipy.optimize.minimize doesn't seem to like a 32-bit Jacobian, so we convert to 64
-        return self.neural_net[net_index].predict_cost_gradient_unscaled(params).astype(np.float64)
+        return self.neural_net[net_index].predict_cost_gradient_unscaled(scaled_params).astype(np.float64)
 
 
     def predict_costs_from_param_array(self,params,net_index=None):

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2219,10 +2219,10 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
                 `perform_scaling` is `False`.
         '''
         # Determine the predicted cost and uncertainty.
-        cost, uncertainty = self.gaussian_process.predict(
+        cost, uncertainty = self.predict_cost(
             params,
             perform_scaling=perform_scaling,
-            return_std=True,
+            return_uncertainty=True,
         )
 
         # Calculate the biased cost.

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2027,9 +2027,10 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
             
 
             scaled_start_parameters = self.params_scaler.transform([start_params])
-            scaled_search_region = self.params_scaler.transform(np.array(self.search_region).T)
+            scaled_search_region = self.params_scaler.transform(np.array(self.search_region).T).T
+            
             result = so.minimize(self.predict_biased_cost, scaled_start_parameters, 
-                                 bounds=scaled_search_region.T, tol=self.search_precision)
+                                 bounds=scaled_search_region, tol=self.search_precision)
             if result.fun < next_cost:
                 next_params = result.x
                 next_cost = result.fun

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1591,6 +1591,8 @@ class MachineLearner(Learner):
             scaled_start_parameters = self.params_scaler.transform(
                 [start_params],
             )
+            # Extract 1D array from 2D array.
+            scaled_start_parameters = scaled_start_parameters[0]
             result = so.minimize(
                 scaled_figure_of_merit_function,
                 scaled_start_parameters,

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1927,11 +1927,9 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         }
         self.archive_dict.update(new_values_dict)
 
-    def _update_params_scaler(self, scaler_samples=None):
+    def _update_params_scaler(self):
         '''
-        Initialize or update the parameter scaling.
-        
-        This method is called every fit.
+        Initialize or update the parameter scaling. This is called every fit
         '''
 
         self.params_scaler = skp.StandardScaler(with_mean=True, with_std=True)

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2004,7 +2004,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         Predict the biased cost at the given parameters.
         
         The bias function is:
-            biased_cost = cost_bias*pred_cost - uncer_bias*pred_uncer
+            `biased_cost = cost_bias*pred_cost - uncer_bias*pred_uncer`
             
         No scaling is done in this function. It is assumed the params input are
         already scaled.

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2027,7 +2027,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         self.update_search_params()
         next_params = None
         next_cost = float('inf')
-        for start_params in self.search_params: 
+        for start_params in self.search_params:
             # Scale the params and bounds before putting into the minimize function
             # Otherwise, it may break
             # We do the scaling *before* putting them in, so the predict cost/gradient method

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1815,7 +1815,6 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
             'generation_num': self.generation_num,
             'update_hyperparameters': self.update_hyperparameters,
             'hyperparameter_searches': self.hyperparameter_searches,
-            'scaler_samples': None,
         }
         self.archive_dict.update(new_values_dict)
 
@@ -1928,7 +1927,7 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         }
         self.archive_dict.update(new_values_dict)
 
-    def _update_params_scaler(self, scaler_samples=None):
+    def _update_params_scaler(self):
         """
         Initialize or update the parameter scaling. This is called every fit
         """

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -1927,10 +1927,12 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
         }
         self.archive_dict.update(new_values_dict)
 
-    def _update_params_scaler(self):
-        """
-        Initialize or update the parameter scaling. This is called every fit
-        """
+    def _update_params_scaler(self, scaler_samples=None):
+        '''
+        Initialize or update the parameter scaling.
+        
+        This method is called every fit.
+        '''
 
         self.params_scaler = skp.StandardScaler(with_mean=True, with_std=True)
         self.params_scaler.fit(self.all_params)

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2115,9 +2115,9 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
             # we use here does not scale the inputs inside the function 
 
             scaled_start_parameters = self.params_scaler.transform([start_params])
-            scaled_search_region = self.params_scaler.transform(np.array(search_bounds).T)
+            scaled_search_region = self.params_scaler.transform(np.array(search_bounds).T).T
             result = so.minimize(self.predict_biased_cost, scaled_start_parameters, 
-                                 bounds=scaled_search_region.T, tol=self.search_precision)
+                                 bounds=scaled_search_region, tol=self.search_precision)
             curr_best_params = self.params_scaler.inverse_transform([result.x])[0]
             (curr_best_cost,curr_best_uncer) = self.gaussian_process.predict(curr_best_params[np.newaxis,:],return_std=True)
             if curr_best_cost<self.predicted_best_scaled_cost:

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -2001,9 +2001,13 @@ class GaussianProcessLearner(MachineLearner, mp.Process):
 
     def predict_biased_cost_unscaled(self,params):
         '''
-        Predicts the biased cost at the given parameters. The bias function is:
-            biased_cost = cost_bias*pred_cost - uncer_bias*pred_uncer. No scaling
-            is done in this function. It is assumed the params input are already scaled
+        Predict the biased cost at the given parameters.
+        
+        The bias function is:
+            biased_cost = cost_bias*pred_cost - uncer_bias*pred_uncer
+            
+        No scaling is done in this function. It is assumed the params input are
+        already scaled.
 
         Returns:
             pred_bias_cost (float): Biased cost predicted at the given parameters

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -763,7 +763,7 @@ class NeuralNet():
         '''
         return self._unscale_gradient(self.net.predict_cost_gradient(self._scale_params(params)))
 
-    def predict_cost_minimize(self,params):
+    def predict_cost_unscaled(self,params):
         '''
         Produces a prediction of cost from the neural net at params.
 
@@ -774,7 +774,7 @@ class NeuralNet():
         '''
         return self.net.predict_cost(params)
 
-    def predict_cost_gradient_minimize(self,params):
+    def predict_cost_gradient_unscaled(self,params):
         '''
         Produces a prediction of the gradient of the cost function at params.
 

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -763,6 +763,28 @@ class NeuralNet():
         '''
         return self._unscale_gradient(self.net.predict_cost_gradient(self._scale_params(params)))
 
+    def predict_cost_minimize(self,params):
+        '''
+        Produces a prediction of cost from the neural net at params.
+
+        Must not be called before fit_neural_net().
+
+        Returns:
+            float : Predicted cost at parameters
+        '''
+        return self.net.predict_cost(params)
+
+    def predict_cost_gradient_minimize(self,params):
+        '''
+        Produces a prediction of the gradient of the cost function at params.
+
+        Must not be called before fit_neural_net().
+
+        Returns:
+            float : Predicted gradient at parameters
+        '''
+        return self.net.predict_cost_gradient(params)
+
     def start_opt(self):
         '''
         Starts an optimisation run. Until stop_opt() is called, predict_cost() and

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -741,49 +741,95 @@ class NeuralNet():
                 all_costs,
                 self.initial_epochs if first_fit else self.subsequent_epochs)
 
-    def predict_cost(self,params):
+    def predict_cost(self, params, perform_scaling=True):
         '''
-        Produces a prediction of cost from the neural net at params.
+        Predict the cost from the neural net for `params`.
 
-        Must not be called before fit_neural_net().
+        This method must not be called before `self.fit_neural_net()`.
+
+        Args:
+            params (array): A 1D array containing the values for each parameter.
+                These should be in real/unscaled units if `perform_scaling` is
+                `True` or they should be in scaled units if `perform_scaling` is
+                `False`.
+            perform_scaling (bool, optional): Whether or not the parameters and
+                costs should be scaled. If `True` then this method takes in
+                parameter values in real/unscaled units then returns a predicted
+                cost in real/unscaled units. If `False`, then this method takes
+                parameter values in scaled units and returns a cost in scaled
+                units. Note that this method cannot determine on its own if the
+                values in `params` are in real/unscaled units or scaled units;
+                it is up to the caller to pass the correct values. Defaults to
+                `True`.
 
         Returns:
-            float : Predicted cost at parameters
+            cost (float): Predicted cost for `params`. This will be in
+                real/unscaled units if `perform_scaling` is `True` or it will be
+                in scaled units if `perform_scaling` is `False`.
         '''
-        return self._unscale_cost(self.net.predict_cost(self._scale_params(params)))
+        # Scale the input parameters if set to do so.
+        if perform_scaling:
+            scaled_params = self._scale_params(params)
+        else:
+            scaled_params = params
 
-    def predict_cost_gradient(self,params):
+        # Generate the predicted cost.
+        predicted_scaled_cost = self.net.predict_cost(scaled_params)
+
+        # Un-scale the cost if set to do so.
+        if perform_scaling:
+            cost = self._unscale_cost(predicted_scaled_cost)
+        else:
+            cost = predicted_scaled_cost
+
+        return cost
+
+    def predict_cost_gradient(self, params, perform_scaling=True):
         '''
-        Produces a prediction of the gradient of the cost function at params.
+        Predict the gradient of the cost function at `params`.
 
-        Must not be called before fit_neural_net().
+        This method must not be called before `self.fit_neural_net()`.
+
+        Args:
+            params (array): A 1D array containing the values for each parameter.
+                These should be in real/unscaled units if `perform_scaling` is
+                `True` or they should be in scaled units if `perform_scaling` is
+                `False`.
+            perform_scaling (bool, optional): Whether or not the parameters and
+                costs should be scaled. If `True` then this method takes in
+                parameter values in real/unscaled units then returns a predicted
+                cost gradient in real/unscaled units. If `False`, then this
+                method takes parameter values in scaled units and returns a cost
+                gradient in scaled units. Note that this method cannot determine
+                on its own if the values in `params` are in real/unscaled units
+                or scaled units; it is up to the caller to pass the correct
+                values. Defaults to `True`.
 
         Returns:
-            float : Predicted gradient at parameters
+            cost_gradient (float): The predicted gradient at `params`. This will
+                be in real/unscaled units if `perform_scaling` is `True` or it
+                will be in scaled units if `perform_scaling` is `False`.
         '''
-        return self._unscale_gradient(self.net.predict_cost_gradient(self._scale_params(params)))
+        # Scale the input parameters if set to do so.
+        if perform_scaling:
+            scaled_params = self._scale_params(params)
+        else:
+            scaled_params = params
 
-    def predict_cost_minimization(self,scaled_params):
-        '''
-        Produces a prediction of cost from the neural net at params.
-        Used when the params input are prescaled
-        Must not be called before fit_neural_net().
+        # Generate the cost gradient prediction.
+        predicted_scaled_cost_gradient = self.net.predict_cost_gradient(
+            scaled_params
+        )
 
-        Returns:
-            float : Predicted cost at parameters
-        '''
-        return self.net.predict_cost(scaled_params)
+        # Un-scaled the cost if set to do so.
+        if perform_scaling:
+            cost_gradient = self._unscale_gradient(
+                predicted_scaled_cost_gradient,
+            )
+        else:
+            cost_gradient = predicted_scaled_cost_gradient
 
-    def predict_cost_gradient_minimization(self,scaled_params):
-        '''
-        Produces a prediction of the gradient of the cost function at params.
-        Used when the params input are prescaled
-        Must not be called before fit_neural_net().
-
-        Returns:
-            float : Predicted gradient at parameters
-        '''
-        return self.net.predict_cost_gradient(scaled_params)
+        return cost_gradient
 
     def start_opt(self):
         '''

--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -763,27 +763,27 @@ class NeuralNet():
         '''
         return self._unscale_gradient(self.net.predict_cost_gradient(self._scale_params(params)))
 
-    def predict_cost_unscaled(self,params):
+    def predict_cost_minimization(self,scaled_params):
         '''
         Produces a prediction of cost from the neural net at params.
-
+        Used when the params input are prescaled
         Must not be called before fit_neural_net().
 
         Returns:
             float : Predicted cost at parameters
         '''
-        return self.net.predict_cost(params)
+        return self.net.predict_cost(scaled_params)
 
-    def predict_cost_gradient_unscaled(self,params):
+    def predict_cost_gradient_minimization(self,scaled_params):
         '''
         Produces a prediction of the gradient of the cost function at params.
-
+        Used when the params input are prescaled
         Must not be called before fit_neural_net().
 
         Returns:
             float : Predicted gradient at parameters
         '''
-        return self.net.predict_cost_gradient(params)
+        return self.net.predict_cost_gradient(scaled_params)
 
     def start_opt(self):
         '''

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -472,11 +472,24 @@ class NullQueueListener():
         pass
 
 class ParameterScaler(skp.MinMaxScaler):
+    '''
+    Class for scaling parameters based on their min/max value constraints.
+
+    All parameters are mapped (by default) between [0, 1] by linearly rescaling them,
+    In particular the minimum value for a parameter is mapped to 0 and the maximum
+    value is mapped to 1.
+
+    This class inherits from scikit-learn's `MinMaxScaler`. The primary difference is that
+    values are scaled by the minimum and maximum values set by the user, rather
+    than the minimum and maximum values actually used in a dataset.
+
+    Args:
+        min_boundary (np.array): The minimum values allowed for each parameter.
+        max_boundary (np.array): The maximum values allowed for each parameter.
+        *args: Additional arguments are passed to `MinMaxScaler.__init__()`.
+        **kwargs: Arbitrary keyword arguments are passed to `MinMaxScaler.__init__()`.
+    '''
     def __init__(self, min_boundary, max_boundary, *args, **kwargs):
-        '''
-        Class to scale the parameters of the gaussian process. 
-        All parameters are mapped (by default) between [0, 1] using min and max boundaries
-        '''
         if len(min_boundary) != len(max_boundary):
             raise ValueError(
                 "The minimum and maximum boundary arrays must have the same lengths but "

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -505,7 +505,7 @@ class ParameterScaler(skp.MinMaxScaler):
         '''
         Teach the scaler that we want to scale things based on the minimum and maximum boundaries
         '''
-        X = [self.min_boundary, self.max_boundary]  # Maybe need transpose of this.
+        X = [self.min_boundary, self.max_boundary]
         return super().partial_fit(X,*args, **kwargs)
 
 

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import scipy.io as si
+import sklearn.preprocessing as skp
 import pickle
 import logging
 import datetime
@@ -470,6 +471,25 @@ class NullQueueListener():
         '''
         pass
 
+class ParameterScaler(skp.MinMaxScaler):
+    def __init__(self, min_boundary, max_boundary, *args, **kwargs):
+        '''
+        Class to scale the parameters of the gaussian process. 
+        All parameters are mapped (by default) between [0, 1] using min and max boundaries
+        '''
+        if len(min_boundary) != len(max_boundary):
+            raise("The minimum and maximum boundary arrays must have the same lengths")
+
+        self.min_boundary = min_boundary
+        self.max_boundary = max_boundary
+        return super().__init__(*args, **kwargs)
+
+    def partial_fit(self, X=None, *args, **kwargs):
+        '''
+        Teach the scaler that we want to scale things based on the minimum and maximum boundaries
+        '''
+        X = [self.min_boundary, self.max_boundary]  # Maybe need transpose of this.
+        return super().partial_fit(X,*args, **kwargs)
 
 
     

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -478,7 +478,11 @@ class ParameterScaler(skp.MinMaxScaler):
         All parameters are mapped (by default) between [0, 1] using min and max boundaries
         '''
         if len(min_boundary) != len(max_boundary):
-            raise("The minimum and maximum boundary arrays must have the same lengths")
+            raise ValueError(
+                "The minimum and maximum boundary arrays must have the same lengths but "
+                f"min_boundary had length {len(min_boundary)} while max_boundary had length "
+                f" {len(max_boundary)}."
+            )
 
         self.min_boundary = min_boundary
         self.max_boundary = max_boundary

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -830,11 +830,6 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         #Trust region
         self.has_trust_region = bool(np.array(training_dict['has_trust_region']))
         self.trust_region = np.squeeze(np.array(training_dict['trust_region'], dtype=float))
-        # Try to extract options not present in archives from M-LOOP <= 3.1.1
-        if 'length_scale_bounds' in training_dict:
-            self.length_scale_bounds = mlu.safe_cast_to_array(training_dict['length_scale_bounds'])
-        if 'noise_level_bounds' in training_dict:
-            self.noise_level_bounds = mlu.safe_cast_to_array(training_dict['noise_level_bounds'])
 
         self.fit_gaussian_process()
 

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -906,7 +906,10 @@ class GaussianProcessVisualizer(mll.GaussianProcessLearner):
         for ind in range(self.num_params):
             sample_parameters = np.array([cross_section_center for _ in range(points)])
             sample_parameters[:, ind] = cross_parameter_arrays[ind]
-            (costs, uncers) = self.gaussian_process.predict(sample_parameters,return_std=True)
+            if self.params_scaler is not None:
+                scaled_sample_parameters = self.params_scaler.transform(sample_parameters)
+
+            (costs, uncers) = self.gaussian_process.predict(scaled_sample_parameters,return_std=True)
             scaled_cost_arrays.append(costs)
             scaled_uncertainty_arrays.append(uncers)
         cross_parameter_arrays = np.array(cross_parameter_arrays)


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a `ParameterScaler` class to `mloop.utilities`.
    - This is based on scikit-learn's `MinMaxScaler`, but uses the provided parameter min/max allowed values rather than using the smallest and largest parameter values used for each parameter in the training dataset.
- Add parameter scaling to the Gaussian process learner.
- Fix the way parameter scaling is done in the neural net class to solve issues with `scipy.optimize.minimize()`.
- Change the default values for `length_scale` and `length_scale_bounds` for `GaussianProcessLearner`.
    - Previously `length_scale` defaulted to `1` and `length_scale_bounds` defaulted to `[1e-5, 1e5]` in real/unscaled units. The bounds are particularly problematic if the allowed parameter ranges are very large (e.g `~1e10`) or very small (e.g `~1e-10`) and essentially prevent the `GaussianProcessLearner` from working in those cases.
    - Since the other changes in the PR enable M-LOOP to work with large parameter ranges, this PR also changes these default values to be commensurate with the allowed parameter ranges. Now `length_scale` defaults to `0.1` times the allowed range for each parameter and `length_scale_bounds` defaults to be between `1e-3` and `1e1` times the allowed range for each parameter.
    - Now the values `length_scale_bounds` and `noise_level_bounds` are taken from the training archive if a training archive with those values is provided and the user does not provide values for those optional arguments.
- Additionally much refactoring was done.

The parameter scaling behavior with and without this pull request can be seen by running the lightly-modified tutorial script below. There is a scale_factor parameter at the beginning of the script that controls the scale of the parameters fed into the learner. Previously, setting scale_factor to large numbers (e.g. 1e10) caused issues where the so.minimize function in find_next_parameters would incorrectly predict identical points many times and fail to find optimal solutions. 

The changes in this PR treat parameters identically regardless of the scale factor for both the neural_net and gaussian_process controllers.

Example script:
```
# Imports for python 2 compatibility
from __future__ import absolute_import, division, print_function

__metaclass__ = type

# Imports for M-LOOP
import mloop.interfaces as mli
import mloop.controllers as mlc
import mloop.visualizations as mlv

# Other imports
import numpy as np
import time
scale_factor = 1e10 #1

# Declare your custom class that inherits from the Interface class
class CustomInterface(mli.Interface):

    # Initialization of the interface, including this method is optional
    def __init__(self):
        # You must include the super command to call the parent class, Interface, constructor
        super(CustomInterface, self).__init__()

        # Attributes of the interface can be added here
        # If you want to precalculate any variables etc. this is the place to do it
        # In this example we will just define the location of the minimum
        self.minimum_params = np.array([0, 0.1, -0.1])*scale_factor

    # You must include the get_next_cost_dict method in your class
    # this method is called whenever M-LOOP wants to run an experiment
    def get_next_cost_dict(self, params_dict):
        # Get parameters from the provided dictionary
        params = params_dict['params']

        # Here you can include the code to run your experiment given a particular set of parameters
        # In this example we will just evaluate a sum of sinc functions
        cost = -np.sum(np.sinc((params - self.minimum_params)/scale_factor))
        # There is no uncertainty in our result
        uncer = 0
        # The evaluation will always be a success
        bad = False
        # Add a small time delay to mimic a real experiment
        time.sleep(1)

        # The cost, uncertainty and bad boolean must all be returned as a dictionary
        # You can include other variables you want to record as well if you want
        cost_dict = {'cost': cost, 'uncer': uncer, 'bad': bad}
        return cost_dict


def main():
    # M-LOOP can be run with three commands

    # First create your interface
    interface = CustomInterface()
    # Next create the controller. Provide it with your interface and any options you want to set
    controller = mlc.create_controller(interface,
                                       controller_type='neural_net',
                                       no_delay=False,
                                       max_num_runs=1000,
                                       target_cost=-2.999,
                                       num_params=3,
                                       min_boundary=np.array([-2, -2, -2])*scale_factor,
                                       max_boundary=np.array([2, 2, 2])*scale_factor)
    # To run M-LOOP and find the optimal parameters just use the controller method optimize
    controller.optimize()

    # The results of the optimization will be saved to files and can also be accessed as attributes of the controller.
    print('Best parameters found:')
    print(controller.best_params)

    # You can also run the default sets of visualizations for the controller with one command
    mlv.show_all_default_visualizations(controller)


# Ensures main is run when this code is run as a script
if __name__ == '__main__':
    main()
```

Example log file output looked like this when scale_factor=1e10:

> INFO     Run:625 (machine learner)
> INFO     params [-8.59059920e+08  3.74652636e+08 -1.80498396e+08]
> INFO     cost -2.970473975708986 +/- 0.0
> INFO     Run:626 (machine learner)
> INFO     params [-8.59059920e+08  3.74652636e+08 -1.80498396e+08]
> INFO     cost -2.970473975708986 +/- 0.0
> INFO     Run:627 (trainer)
> INFO     params [-1.35482105e+10  1.74986137e+10  1.60706858e+10]
> INFO     cost 0.5312541925859317 +/- 0.0
> INFO     Run:628 (machine learner)
> INFO     params [-8.59059920e+08  3.74652636e+08 -1.80498396e+08]
> INFO     cost -2.970473975708986 +/- 0.0
> INFO     Run:629 (machine learner)
> INFO     params [-8.59059920e+08  3.74652636e+08 -1.80498396e+08]
> INFO     cost -2.970473975708986 +/- 0.0
> INFO     Run:630 (machine learner)
> INFO     params [-8.59059920e+08  3.74652636e+08 -1.80498396e+08]
> INFO     cost -2.970473975708986 +/- 0.0
> INFO     Run:631 (trainer)


![image](https://user-images.githubusercontent.com/83101679/149823309-af365db7-5f64-4f7f-8fbe-8b650adf8a09.png)
![image](https://user-images.githubusercontent.com/83101679/149823333-f6e4ecc0-a461-4e27-884b-fe70b095377e.png)
Attached are images of the parameters vs. run # for before and after this PR. Plots were created using the show_all_default_visualizations method. I set max_run_num=300, target_cost=-2.999, and scale_factor=1e10. You can see that before this PR, the learner predicts the same points many times and does not converge to the target cost in 300 runs. Whereas, with the fixes in the PR, it converges in ~80 runs.


@qctrl/support
