### PR TITLE
Datetime fixes

### DIFF
--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -126,7 +126,7 @@ class Controller():
                  **kwargs):
 
         #Make logger
-        self.remaining_kwargs = mlu._config_logger(**kwargs)
+        self.remaining_kwargs = mlu._config_logger(start_datetime=start_datetime, **kwargs)
         self.log = logging.getLogger(__name__)
 
         #Variable that are included in archive

--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -177,9 +177,14 @@ class Controller():
 
         #Other options
         if start_datetime is None:
-            self.start_datetime = datetime.datetime.now()
+            start_datetime = datetime.datetime.now()
+        if isinstance(start_datetime, datetime.datetime):
+            self.start_datetime = start_datetime
         else:
-            self.start_datetime = datetime.datetime(start_datetime)
+            raise ValueError(
+                "start_datetime must be of type datetime.datetime but was "
+                f"{start_datetime} (type: {type(start_datetime)})."
+            )
         self.max_num_runs = float(max_num_runs)
         if self.max_num_runs<=0:
             self.log.error('Number of runs must be greater than zero. max_num_runs:'+repr(self.max_num_run))

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -50,6 +50,7 @@ def config_logger(**kwargs):
 def _config_logger(log_filename = default_log_filename,
                   file_log_level=logging.DEBUG,
                   console_log_level=logging.INFO,
+                  start_datetime=None,
                   **kwargs):
     '''
     Configure and the root logger.
@@ -58,6 +59,11 @@ def _config_logger(log_filename = default_log_filename,
         log_filename (Optional [string]) : Filename prefix for log. Default M-LOOP run . If None, no file handler is created
         file_log_level (Optional[int]) : Level of log output for file, default is logging.DEBUG = 10
         console_log_level (Optional[int]) :Level of log output for console, default is logging.INFO = 20
+        start_datetime (Optional datetime.datetime): The date and time to use in
+            the filename suffix, represented as an instance of the datetime
+            class defined in the datetime module. If set to None, then this
+            function will use the result returned by datetime.datetime.now().
+            Default None.
     
     Returns:
         dictionary: Dict with extra keywords not used by the logging configuration.
@@ -67,7 +73,7 @@ def _config_logger(log_filename = default_log_filename,
     if len(log.handlers) == 0:
         log.setLevel(min(file_log_level,console_log_level))
         if log_filename is not None:
-            filename_suffix = generate_filename_suffix('log')
+            filename_suffix = generate_filename_suffix('log', start_datetime)
             full_filename = log_filename + filename_suffix
             filename_with_path = os.path.join(log_foldername, full_filename)
             # Create folder if it doesn't exist, accounting for any parts of the


### PR DESCRIPTION
This PR (mostly) fixes two issues related to specifying `start_datetime` for an optimization, which controls the timestamp appended to file names.

Changes proposed in this pull request:

- `Controller.__init__()` previously set `self.start_datetime = datetime.datetime(start_datetime)` if `start_datetime` was provided. This would always error because `datetime.datetime()` expects 3 arguments. This has been fixed.
  - Now a type check is run on any user-provided value and then that value is directly set as `self.start_datetime` without passing it through `datetime.datetime()`. This makes it possible for the user to provide a `datetime.datetime` instance.
- `start_datetime` can now be passed when instantiating an `Interface` in order to control the timestamp used for the log file.
  - Note that it must be provided when instantiating the `Interface`, not just when creating a `Controller`. This is because the timestamp must be provided during the first call to `config_logger()`, which occurs during the `Interface` instantiation before a `Controller` is created. This isn't ideal, but I don't see a good way around it.
