### PR TITLE
Fixed a matplotlib deprecation warning in `NeuralNetVisualizer.plot_density_surface()`

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1552,7 +1552,7 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
                 np.linspace(self.min_boundary[1], self.max_boundary[1], points))
         zs_list = self.predict_costs_from_param_array(list(zip(xs.flatten(),ys.flatten())))
         zs = np.array(zs_list).reshape(points,points)
-        plt.pcolormesh(xs,ys,zs)
+        plt.pcolormesh(xs, ys, zs, shading='nearest')
         plt.scatter(self.all_params[:,0], self.all_params[:,1], c=self.all_costs, vmin=np.min(zs), vmax=np.max(zs), s=100)
         plt.colorbar()
         plt.xlabel("Param 0")


### PR DESCRIPTION
Matplotlib isn't happy about the interpolation method used by `pcolormesh()` in `NeuralNetVisualizer.plot_density_surface()` given the dimensions of the data passed to that plotting function. Before this PR, it would produce the deprecation warning presented below. Changing the interpolation to `'nearest'` fixes the issue. It's also the better way to perform the interpolation anyway since then the coloring of the squares is set by their value in their center rather than the value at one of their corners.

```python
MatplotlibDeprecationWarning: shading='flat' when X and Y have the same dimensions as C is deprecated since 3.3.  Either specify the corners of the quadrilaterals with X and Y, or pass shading='auto', 'nearest' or 'gouraud', or set rcParams['pcolor.shading'].  This will become an error two minor releases later.
  plt.pcolormesh(xs,ys,zs)
```

Changes proposed in this pull request:

- Set `shading='nearest'` in the call to `plt.pcolormesh` in `NeuralNetVisualizer.plot_density_surface()`