### PR TITLE
Add `num_training_runs` to the docs

### DIFF
--- a/examples/gaussian_process_complete_config.txt
+++ b/examples/gaussian_process_complete_config.txt
@@ -29,6 +29,7 @@ no_delay = True                        #whether to wait for the GP to make predi
 #Training source options
 training_type = 'random'               #training type can be random, differential_evolution, or nelder_mead
 first_params = [1.9, -1.0]             #first parameters to try in initial training
+num_training_runs = 20                 #number of training runs before using machine learner to pick parameters
 training_filename = None               #filename for training from previous experiment
 
 #if you use nelder_mead for the initial training source see the CompleteNelderMeadConfig.txt for options. 

--- a/examples/neural_net_complete_config.txt
+++ b/examples/neural_net_complete_config.txt
@@ -24,6 +24,7 @@ update_hyperparameters = False         #whether hyperparameters should be tuned 
 #Training source options
 training_type = 'random'               #training type can be random, differential_evolution, or nelder_mead
 first_params = [1.9, -1.0]             #first parameters to try in initial training
+num_training_runs = 20                 #number of training runs before using machine learner to pick parameters
 training_filename = None               #filename for training from previous experiment
 
 #if you use nelder_mead for the initial training source see the CompleteNelderMeadConfig.txt for options. 


### PR DESCRIPTION
This PR adds `num_training_runs` to the list of training options in the Gaussian process and neural net complete config examples.
