### PR TITLE
Correct some cost scaling for the neural net

### DIFF
--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -1431,14 +1431,18 @@ class NeuralNetVisualizer(mll.NeuralNetLearner):
         res = []
         for net_index in range(self.num_nets):
             cross_parameter_arrays = [ np.linspace(min_p, max_p, points) for (min_p,max_p) in zip(self.min_boundary,self.max_boundary)]
-            scaled_cost_arrays = []
+            cost_arrays = []
             for ind in range(self.num_params):
                 sample_parameters = np.array([cross_section_center for _ in range(points)])
                 sample_parameters[:, ind] = cross_parameter_arrays[ind]
-                costs = self.predict_costs_from_param_array(sample_parameters, net_index)
-                scaled_cost_arrays.append(costs)
+                costs = self.predict_costs_from_param_array(
+                    sample_parameters,
+                    net_index,
+                    perform_scaling=True,
+                )
+                cost_arrays.append(costs)
             cross_parameter_arrays = np.array(cross_parameter_arrays)
-            cost_arrays = self.cost_scaler.inverse_transform(np.array(scaled_cost_arrays))
+            cost_arrays = np.array(cost_arrays)
             res.append((cross_parameter_arrays, cost_arrays))
         return res
 


### PR DESCRIPTION
This PR adjusts some parts of the `NeuralNetLearner` and `NeuralNetVisualizer` classes to properly use their `self.cost_scaler` attribute. These changes don't actually have any effect at the moment because the `NeuralNetLearner` cost scaler doesn't actually change values currently, but it's good to have this set up correctly in case that changes in the future.

As a quick aside, the reason the `NeuralNetLearner` cost scaler doesn't do anything is because it is created as `skp.StandardScaler(with_mean=False, with_std=False)` so it doesn't shift the mean to 0 or scale the values, so it essentially just applies the identity. The actual scaling of the costs and parameters are handled by the `NeuralNet` class from `neuralnet.py`.

Changes proposed in this pull request:

- Properly account for `self.cost_scaler` in `NeuralNetLearner` and `NeuralNetVisualizer`.
