### PR TITLE
Have M-LOOP create its own numpy random number generator

### DIFF
--- a/mloop/neuralnet.py
+++ b/mloop/neuralnet.py
@@ -7,7 +7,6 @@ import base64
 
 import mloop.utilities as mlu
 import numpy as np
-import numpy.random as nr
 import sklearn.preprocessing as skp
 import tensorflow as tf
 

--- a/mloop/testing.py
+++ b/mloop/testing.py
@@ -7,7 +7,6 @@ __metaclass__ = type
 import numpy as np
 import threading
 import mloop.utilities as mlu
-import numpy.random as nr
 import logging
 import os
 import time
@@ -51,8 +50,8 @@ class TestLandscape():
             min_scale (float): Natural log of minimum scale factor. Default 0.
             max_scale (float): Natural log of maximum scale factor. Default 3.
         '''
-        mini = min_region + nr.rand(self.num_params) * (max_region - min_region)
-        scal = np.exp(min_scale + nr.rand(self.num_params) * (max_scale - min_scale))
+        mini = mlu.rng.uniform(min_region, max_region)
+        scal = np.exp(mlu.rng.uniform(min_scale, max_scale))
         self.set_quadratic_landscape(minimum = mini,scale = scal)
     
     def set_quadratic_landscape(self, minimum = None, scale = None):
@@ -102,7 +101,7 @@ class TestLandscape():
         
         self.noise_prop = proportional
         self.noise_abs = absolute
-        self.noise_function = lambda p,c,u : (c *(1 + nr.normal()*self.noise_prop) + nr.normal()*self.noise_abs,np.sqrt((c*self.noise_prop)**2 + (self.noise_abs)**2))
+        self.noise_function = lambda p,c,u : (c *(1 + mlu.rng.normal()*self.noise_prop) + mlu.rng.normal()*self.noise_abs,np.sqrt((c*self.noise_prop)**2 + (self.noise_abs)**2))
     
     def set_bad_region(self, min_boundary, max_boundary, bad_cost=None, bad_uncer=None):
         '''

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -12,7 +12,6 @@ import datetime
 import sys
 import os
 import numpy as np
-import numpy.random as nr
 import base64
 import mloop
 
@@ -41,6 +40,12 @@ mloop_path = os.path.dirname(mloop.__file__)
 
 #Set numpy to have no limit on printing to ensure all values are saved
 np.set_printoptions(threshold=np.inf)
+
+# Create a random number generator that can be used throughout M-LOOP. Users
+# could also seed this generator if they want to fix the random numbers
+# generated in M-LOOP (though this won't affect the generators used by M-LOOP
+# dependencies, such as tensorflow).
+rng = np.random.default_rng()
 
 def config_logger(**kwargs):
     '''
@@ -131,7 +136,7 @@ def generate_filename_suffix(file_type, file_datetime=None, random_bytes=False):
     date_string = datetime_to_string(file_datetime)
     filename_suffix = '_' + date_string 
     if random_bytes:
-        random_string = base64.urlsafe_b64encode(nr.bytes(6)).decode()
+        random_string = base64.urlsafe_b64encode(rng.bytes(6)).decode()
         filename_suffix = filename_suffix + '_' + random_string
     filename_suffix = filename_suffix + '.' + file_type
     return filename_suffix


### PR DESCRIPTION
Previously M-LOOP would use the default numpy random number generator instance accessed via e.g. `numpy.random.random()`. Generally numpy suggests creating a unique random number generator instance instead. That approach avoids potential conflicts with other packages and user code.

For example, in the wild I've seen an experiment which resets numpy's default random number generator seed before each run. That caused M-LOOP to always suggest the same set of "random" parameter values during training, which is problematic. After this PR, M-LOOP will have its own numpy random number generator instance, so when the default instance's seed is changed/reset by outside code, M-LOOP won't be affected. The instance is an attribute of the `mloop.utilities` module, so it can be accessed/used/manipulated as needed, potentially even by user code. In particular it is `mloop.utilities.rng`.

Changes proposed in this pull request:

- Have M-LOOP use its own numpy random number generator instance rather than the default one.
