### PR TITLE
Fix `show_all_default_visualizations()` for random and Nelder-Mead learners.

### DIFF
--- a/docs/visualizations.rst
+++ b/docs/visualizations.rst
@@ -134,16 +134,16 @@ Differential Evolution
   This plot displays the measured costs for each generation.
   Because there are multiple runs per generation, there are many different values for the cost plotted for each generation.
 
-Nelder–Mead
+Nelder-Mead
 -----------
 
-As of yet there is no visualization class implemented for the Nelder–Mead learner.
-The controller's archive may still be plotted though when Nelder–Mead is used.
+As of yet there are no visualizations implemented for the Nelder-Mead learner.
+The controller's archive may still be plotted though when Nelder-Mead is used.
 
 Random
 ------
 
-As of yet there is no visualization class implemented for the random learner.
+As of yet there are no visualizations implemented for the random learner.
 The controller's archive may still be plotted though when the random controller is used.
 
 Reproducing visualizations

--- a/mloop/utilities.py
+++ b/mloop/utilities.py
@@ -299,6 +299,8 @@ def get_controller_type_from_learner_archive(learner_filename):
         'gaussian_process_learner': 'gaussian_process',
         'neural_net_learner': 'neural_net',
         'differential_evolution': 'differential_evolution',
+        'random_learner': 'random',
+        'nelder_mead_learner': 'nelder_mead',
     }
     if archive_type in ARCHIVE_CONTROLLER_MAPPING:
         controller_type = ARCHIVE_CONTROLLER_MAPPING[archive_type]

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -216,11 +216,17 @@ def create_learner_visualizer_from_archive(filename, controller_type=None, **kwa
         log.debug('Creating neural net visualizer.')
         visualizer = NeuralNetVisualizer(filename, **kwargs)
     elif controller_type == 'gaussian_process':
-        log.debug('Creating gaussian process visualizer.')
+        log.debug('Creating Gaussian process visualizer.')
         visualizer = GaussianProcessVisualizer(filename, **kwargs)
     elif controller_type == 'differential_evolution':
         log.debug('Creating differential evolution visualizer.')
         visualizer = DifferentialEvolutionVisualizer(filename, **kwargs)
+    elif controller_type == 'random':
+        log.debug('Creating random visualizer.')
+        visualizer = RandomVisualizer(filename, **kwargs)
+    elif controller_type == 'nelder_mead':
+        log.debug('Creating Nelder-Mead visualizer.')
+        visualizer = NelderMeadVisualizer(filename, **kwargs)
     else:
         message = ('create_learner_visualizer_from_archive() not implemented '
                    'for type: {type_}.').format(type_=controller_type)
@@ -598,6 +604,35 @@ class ControllerVisualizer():
             self.param_names,
         )
         plt.legend(artists, legend_labels ,loc=legend_loc)
+
+
+class RandomVisualizer:
+    '''
+    Visualization class for the random learner.
+
+    Currently no learner plots are generated for the random learner. However,
+    controller visualizations may still be generated.
+    '''
+    def __init__(self, filename, file_type=None, **kwargs):
+        pass
+
+    def create_visualizations(self, *args, **kwargs):
+        pass
+
+
+class NelderMeadVisualizer:
+    '''
+    Visualization class for the Nelder-Mead learner.
+
+    Currently no learner plots are generated for the Nelder-Mead learner.
+    However, controller visualizations may still be generated.
+    '''
+    def __init__(self, filename, file_type=None, **kwargs):
+        pass
+
+    def create_visualizations(self, *args, **kwargs):
+        pass
+
 
 def create_differential_evolution_learner_visualizations(filename,
                                                          file_type=None,

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -617,7 +617,11 @@ class RandomVisualizer:
         pass
 
     def create_visualizations(self, *args, **kwargs):
-        pass
+        log = logging.getLogger(__name__)
+        log.warning(
+            "No visualizations are currently implemented for the random "
+            "learner."
+        )
 
 
 class NelderMeadVisualizer:
@@ -631,7 +635,11 @@ class NelderMeadVisualizer:
         pass
 
     def create_visualizations(self, *args, **kwargs):
-        pass
+        log = logging.getLogger(__name__)
+        log.warning(
+            "No visualizations are currently implemented for the Nelder-Mead "
+            "learner."
+        )
 
 
 def create_differential_evolution_learner_visualizations(filename,


### PR DESCRIPTION
This PR adds empty visualizer classes for those two learners. These visualization classes don't currently generate any plots, but they could in the future. Previously, `create_learner_visualizer_from_archive()` would raise a `ValueError` because these learners didn't have an associated visualizer class.

Changes proposed in this pull request:

- Fix `show_all_default_visualizations()` for random and Nelder-Mead learners.