### PR TITLE
Safer parameter boundary enforcement

### DIFF
--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -4,15 +4,18 @@ Module of all the controllers used in M-LOOP. The controllers, as the name sugge
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import os
 import datetime
 from importlib import import_module
+import logging
 import traceback
+
+import numpy as np
+
 from mloop import __version__
 import mloop.utilities as mlu
 import mloop.learners as mll
 import mloop.interfaces as mli
-import logging
-import os
 
 controller_dict = {'random':1,'nelder_mead':2,'gaussian_process':3,'differential_evolution':4,'neural_net':5}
 number_of_controllers = len(controller_dict)
@@ -314,6 +317,12 @@ class Controller():
         Keyword Args:
             **kwargs: any additional data to be attached to file sent to experiment
         '''
+        # Do one last check to ensure parameter values are within the allowed
+        # limits before sending those values to the interface.
+        assert np.all(params >= self.learner.min_boundary)
+        assert np.all(params <= self.learner.max_boundary)
+        
+        # Send the parameters to the interface and update various attributes.
         out_dict = {'params':params}
         out_dict.update(kwargs)
         self.params_out_queue.put(out_dict)

--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -248,7 +248,9 @@ class Learner():
             self.log.error(msg)
             raise ValueError(msg)
         if not self.check_in_boundary(params):
-            self.log.warning('Parameters sent to queue are not within boundaries. Params:' + repr(params))
+            msg = 'Parameters sent to queue are not within boundaries. Params:' + repr(params)
+            self.log.error(msg)
+            raise RuntimeError(msg)
         #self.log.debug('Learner puts params.')
         self.params_out_queue.put(params)
         #self.log.debug('Learner waiting for costs.')


### PR DESCRIPTION
This PR introduces some changes to help ensure that parameter values always remain within their allowed range. This can be an important safety check because the values suggested by M-LOOP are often used to adjust settings for real hardware. Ideally the user's driver code should make it impossible to set that hardware to dangerous value regardless of what M-LOOP requests, but it doesn't hurt to have M-LOOP be extra careful to remain within its user-imposed limits. These checks are particularly important given that M-LOOP supports using third-party controllers/learners. The particular changes to enforce this check are enumerated below.

Changes proposed in this pull request:

- `Learner.put_params_and_get_cost()` will now raise a `RuntimeError` if its suggested parameter values are outside of the allowed boundaries.
  - Previously it would only log a warning.
- `Controller._put_params_and_out_dict()` now checks that parameter values are within the allowed boundaries before sending them to the interface to be tested experimentally.
