### PR TITLE
Have `ControllerVisualizer.plot_cost_vs_run()` support third party controllers

### DIFF
--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -17,7 +17,14 @@ import mloop.utilities as mlu
 import mloop.learners as mll
 import mloop.interfaces as mli
 
-controller_dict = {'random':1,'nelder_mead':2,'gaussian_process':3,'differential_evolution':4,'neural_net':5}
+controller_dict = {
+    'random': 1,
+    'nelder_mead': 2,
+    'gaussian_process': 3,
+    'differential_evolution': 4,
+    'neural_net': 5,
+    'third_party': 6,
+}
 number_of_controllers = len(controller_dict)
 default_controller_archive_filename = 'controller_archive'
 default_controller_archive_file_type = 'txt'

--- a/mloop/visualizations.py
+++ b/mloop/visualizations.py
@@ -285,7 +285,15 @@ def _color_from_controller_name(controller_name):
     Gives a color (as a number between zero an one) corresponding to each controller name string.
     '''
     global cmap
-    return cmap(float(mlc.controller_dict[controller_name])/float(mlc.number_of_controllers))
+    # If controller_name isn't in the mlc.controller_dict dictionary, assume it
+    # is the name of a third party controller provided by an external package.
+    if controller_name not in mlc.controller_dict:
+        controller_name = 'third_party'
+
+    # Determine the color.
+    index = mlc.controller_dict[controller_name]
+    fraction = float(index) / float(mlc.number_of_controllers)
+    return cmap(fraction)
 
 def _color_list_from_num_of_params(num_of_params):
     '''


### PR DESCRIPTION
M-LOOP supports using controllers from third party packages. However, previously `ControllerVisualizer.plot_cost_vs_run()` could not determine what color to plot the values suggested by a third party optimizer. This PR attempts to resolve that issue by adding a new color for third party optimizers. This isn't perfect, for example is two different third party optimizers are used in the same optimization then they'll be given the same color, but it's definitely an improvement.

In the future it would probably be smarter to simply assign a unique color on-the-fly to each of the `out_type`s actually used in an optimization, instead of having a static mapping between learner type and color.

Changes proposed in this pull request:

- `ControllerVisualizer.plot_cost_vs_run()` now supports plotting results from third party controllers
