### PR TITLE
Simplify the color generation for cost vs run plots.

### DIFF
--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -17,15 +17,6 @@ import mloop.utilities as mlu
 import mloop.learners as mll
 import mloop.interfaces as mli
 
-controller_dict = {
-    'random': 1,
-    'nelder_mead': 2,
-    'gaussian_process': 3,
-    'differential_evolution': 4,
-    'neural_net': 5,
-    'third_party': 6,
-}
-number_of_controllers = len(controller_dict)
 default_controller_archive_filename = 'controller_archive'
 default_controller_archive_file_type = 'txt'
 


### PR DESCRIPTION
Previously there was a static mapping of controller type to color. That doesn't jive well with supporting third party controllers, since there's no way to know how many there are. Now colors for cost vs run plots are generated on the fly based on how many different colors are needed.

This PR implements the idea initially suggested in #144.

Changes proposed in this pull request:

- The colors used for `ControllerVisualizer.plot_cost_vs_run()` are now generated on-the-fly based on how many distinct colors are needed.
