### PR TITLE
Add a changelog page to the documentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,7 @@
+.. _sec-changelog:
+
+=========
+Changelog
+=========
+
+M-LOOP's changelog is available on its `Github releases page <https://github.com/michaelhush/M-LOOP/releases>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Contents
    visualizations
    examples
    contributing
+   changelog
    api/index
    
 Indices


### PR DESCRIPTION
The changelog page simply links to the Github releases page, which (should) list the changes in each release. This is convenient as we don't ever need to update the changelog `.rst` file.

Changes proposed in this pull request:

- Added a changelog page to the documentation.
