### PR TITLE
Clip values outside, but close to, boundaries

### DIFF
--- a/mloop/controllers.py
+++ b/mloop/controllers.py
@@ -351,7 +351,7 @@ class Controller():
         self.learner_costs_queue = self.learner.costs_in_queue
         self.end_learner = self.learner.end_event
         self.remaining_kwargs = self.learner.remaining_kwargs
-        self.num_params = self.learner.num_params,
+        self.num_params = self.learner.num_params
         self.min_boundary = self.learner.min_boundary
         self.max_boundary = self.learner.max_boundary
         self.param_names = self.learner.param_names


### PR DESCRIPTION
After https://github.com/michaelhush/M-LOOP/pull/141, M-LOOP's `Controller` class now enforces the parameter value limits, erroring out if they are violated. It has been seen with third party optimizers that the parameter values can sometimes exceed the limits by a tiny amount (e.g. one part in 10^16) due to numerical issues. Although not yet observed, it wouldn't be surprising if this could occur with M-LOOP's built-in optimizers as well.

This PR adjusts `Controller`'s behavior to be tolerant of these small violations, simply clipping them to be within the allowed range. Large/nontrivial violations of the bounds still raise an error. This is intentional as that is typically an indication that the learner is not respecting the parameter boundaries.

Changes proposed in this pull request:

- Coerce parameter values which barely exceed the boundaries into the allowed range during `Controller._put_params_and_out_dict()`.
