### PR TITLE
Add the phrase "Bayesian optimization" to the main page of the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,14 +2,17 @@
 M-LOOP
 ======
 
-The Machine-Learner Online Optimization Package is designed to automatically and rapidly optimize the parameters of a scientific experiment or computer controller system. 
+The Machine-Learning Online Optimization Package is designed to automatically and rapidly optimize the parameters of a scientific experiment or computer controller system. 
 
 .. figure:: _static/M-LOOPandBEC.png
    :alt: M-LOOP optimizing a BEC.
    
    M-LOOP in control of an ultra-cold atom experiment. M-LOOP was able to find an optimal set of ramps to evaporatively cool a thermal gas and form a Bose-Einstein Condensate. 
 
-Using M-LOOP is simple, once the parameters of your experiment is computer controlled, all you need to do is determine a cost function that quantifies the performance of an experiment after a single run. You can then hand over control of the experiment to M-LOOP which will find a global optimal set of parameters that minimize the cost function, by performing a few experiments and testing different parameters. M-LOOP uses machine-learning to predict how the parameters of the experiment relate to the cost, it uses this model to pick the next best parameters to test to find an optimum as quickly as possible. 
+Using M-LOOP is simple, once the parameters of your experiment are computer controlled, all you need to do is determine a cost function that quantifies the performance of an experiment after a single run.
+You can then hand over control of the experiment to M-LOOP which will attempt to find a global optimal set of parameters that minimize the cost function, by performing experiments and testing different parameters.
+M-LOOP uses machine learning to predict how the parameters of the experiment relate to the cost; it uses this model to pick the next best parameters to test to find an optimum as quickly as possible.
+This approach is known as Bayesian optimization.
 
 M-LOOP not only finds an optimal set of parameters for the experiment it also provides a model of how the parameters are related to the costs which can be used to improve the experiment. 
 


### PR DESCRIPTION
Fixes #151 .

Changes proposed in this pull request:

- Mention the phrase "Bayesian optimization" in the main page of the documentation (`index.rst`).
- Minor grammar/formatting edits of the nearby text in `index.rst`.
