### PR TITLE
Install tensorflow-macos for mac instead of tensorflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ def main():
             'matplotlib>=1.5',
             'pytest>=2.9',
             'scikit-learn>=0.18',
-            'tensorflow>=2.0.0',
+            'tensorflow>=2.0.0; sys_platform != "darwin"',
+            'tensorflow-macos>=2.0.0; sys_platform == "darwin"',
         ],
         tests_require=['pytest', 'setuptools>=26'],
         package_data = {


### PR DESCRIPTION
Tensorflow is published separately for macos at https://pypi.org/project/tensorflow-macos.  This change selects that package instead for when the platform is "darwin."  The mac version of tensorflow currently available at https://pypi.org/project/tensorflow is for x86 on an old version of macos.

@qctrl/support

cc @zakv 
