### PR TITLE
Correct `requirements.txt` path in `.readthedocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,4 @@ sphinx:
 
 python:
    install:
-   - requirements: docs/requirements.txt
+   - requirements: requirements.txt


### PR DESCRIPTION
Previously the path to that file was wrong, which caused the docs build to fail.
