### PR TITLE
Fixed trivial error in the RandomLearner

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -460,7 +460,7 @@ class RandomLearner(Learner, threading.Thread):
 
         # Keep track of best parameters to implement trust region.
         self.best_cost = None
-        self.best_parameters = None
+        self.best_params = None
 
         self._set_trust_region(trust_region)
 


### PR DESCRIPTION
Fixes a trivial bug in Random learner where `self.best_parameters` was defined in the `__init__` rather than `self.best_params`.