### PR TITLE
Ignore `.vscode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ docs/_build/
 # PyBuilder
 target/
 
-#Project specific files
+# Project specific files
 ExpConfig.txt
 .DS_Store
+
+# Editor settings
+.vscode/


### PR DESCRIPTION
This tiny PR adds the `.vscode` repo to `.gitignore` so that workspace vscode settings aren't accidentally committed.