### PR TITLE
Fix Nelder-Mead `init_simplex_corner` creation

### DIFF
--- a/mloop/learners.py
+++ b/mloop/learners.py
@@ -573,7 +573,7 @@ class NelderMeadLearner(Learner, threading.Thread):
         if initial_simplex_corner is None:
             diff_roll = (self.diff_boundary - self.init_simplex_disp) * mlu.rng.random(self.num_params)
             diff_roll[diff_roll==float('+inf')]= 0
-            self.init_simplex_corner = self.min_boundary
+            self.init_simplex_corner = np.copy(self.min_boundary)
             self.init_simplex_corner[self.init_simplex_corner==float('-inf')]=0
             self.init_simplex_corner += diff_roll
         else:


### PR DESCRIPTION
As pointed out in #175, the way `self.init_simplex_corner` is created for `NelderMeadLearner` is problematic because it is set equal to `self.min_boundary`. This means that when `self.init_simplex_corner` is later modified, `self.min_boundary` is modified as well. This PR resolves the issue using the approach suggested in #175, namely by assigning a copy of `self.min_boundary` to `self.init_simplex_corner` rather than assigning the original array itself.