### PR TITLE
Drop tensorflow-macos requirement

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,7 +102,7 @@ pytest         >=2.9
 setuptools     >=26
 scikit-learn   >=0.18
 scipy          >=0.17
-tensorflow     >=2.0.0
+tensorflow     >=2.16.1
 ============   =======
 
 These packages should be automatically installed by pip or the script setup.py when you install M-LOOP. The setup script itself requires pytest-runner.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ matplotlib>=1.5
 pytest>=2.9
 scikit-learn>=0.18
 setuptools>=26
-tensorflow>=2.0.0
+tensorflow>=2.16.1

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ def main():
             'matplotlib>=1.5',
             'pytest>=2.9',
             'scikit-learn>=0.18',
-            'tensorflow>=2.0.0; sys_platform != "darwin"',
-            'tensorflow-macos>=2.0.0; sys_platform == "darwin"',
+            'tensorflow>=2.16.1',
         ],
         tests_require=['pytest', 'setuptools>=26'],
         package_data = {

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def main():
             'matplotlib>=1.5',
             'pytest>=2.9',
             'scikit-learn>=0.18',
-            'tensorflow>=2.0.0',
+            'tensorflow>=2.16.1',
         ],
         tests_require=['pytest', 'setuptools>=26'],
         package_data = {

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def main():
             'matplotlib>=1.5',
             'pytest>=2.9',
             'scikit-learn>=0.18',
-            'tensorflow>=2.16.1',
+            'tensorflow>=2.0.0',
         ],
         tests_require=['pytest', 'setuptools>=26'],
         package_data = {


### PR DESCRIPTION
As of [Tensorflow 2.16.1](https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1) `tensorflow-macos` has been deprecated.

Releases of `tensorflow>=2.16.1` cannot be properly installed with `tensorflow-macos`.

The solution is for `m-loop` to drop the `tensorflow-macos` requirement and require `tensorflow>=2.16.1`.